### PR TITLE
Add config loader

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"errors"
+	"flag"
+	"os"
+)
+
+// Config holds application configuration parameters.
+type Config struct {
+	RunAddress     string
+	DatabaseURI    string
+	AccrualAddress string
+	JWTSecret      string
+}
+
+// Load reads configuration from environment variables and command line flags.
+// Flags have priority over environment variables.
+func Load() (Config, error) {
+	cfg := Config{RunAddress: ":8080"}
+
+	if v := os.Getenv("RUN_ADDRESS"); v != "" {
+		cfg.RunAddress = v
+	}
+	if v := os.Getenv("DATABASE_URI"); v != "" {
+		cfg.DatabaseURI = v
+	}
+	if v := os.Getenv("ACCRUAL_SYSTEM_ADDRESS"); v != "" {
+		cfg.AccrualAddress = v
+	}
+	if v := os.Getenv("JWT_SECRET"); v != "" {
+		cfg.JWTSecret = v
+	}
+
+	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+	fs.StringVar(&cfg.RunAddress, "a", cfg.RunAddress, "run address")
+	fs.StringVar(&cfg.DatabaseURI, "d", cfg.DatabaseURI, "database uri")
+	fs.StringVar(&cfg.AccrualAddress, "r", cfg.AccrualAddress, "accrual system address")
+	fs.StringVar(&cfg.JWTSecret, "s", cfg.JWTSecret, "jwt secret")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return Config{}, err
+	}
+
+	if cfg.DatabaseURI == "" {
+		return Config{}, errors.New("database URI is required")
+	}
+	if cfg.AccrualAddress == "" {
+		return Config{}, errors.New("accrual address is required")
+	}
+	if cfg.JWTSecret == "" {
+		return Config{}, errors.New("JWT secret is required")
+	}
+
+	return cfg, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoad_FlagsOverrideEnv(t *testing.T) {
+	t.Setenv("RUN_ADDRESS", ":1111")
+	t.Setenv("DATABASE_URI", "envdb")
+	t.Setenv("ACCRUAL_SYSTEM_ADDRESS", "envacc")
+	t.Setenv("JWT_SECRET", "envjwt")
+
+	os.Args = []string{"cmd", "-a", ":2222", "-d", "flagdb", "-r", "flagacc", "-s", "flagjwt"}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if cfg.RunAddress != ":2222" {
+		t.Errorf("expected run address from flag, got %s", cfg.RunAddress)
+	}
+	if cfg.DatabaseURI != "flagdb" {
+		t.Errorf("expected database uri from flag, got %s", cfg.DatabaseURI)
+	}
+	if cfg.AccrualAddress != "flagacc" {
+		t.Errorf("expected accrual address from flag, got %s", cfg.AccrualAddress)
+	}
+	if cfg.JWTSecret != "flagjwt" {
+		t.Errorf("expected jwt secret from flag, got %s", cfg.JWTSecret)
+	}
+}
+
+func TestLoad_MissingRequired(t *testing.T) {
+	t.Setenv("RUN_ADDRESS", "")
+	t.Setenv("DATABASE_URI", "")
+	t.Setenv("ACCRUAL_SYSTEM_ADDRESS", "")
+	t.Setenv("JWT_SECRET", "")
+
+	os.Args = []string{"cmd"}
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- add `internal/config` package for reading configuration
- load from environment variables then command line flags
- validate mandatory configuration values
- add unit tests verifying flag priority and validation errors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c1e7b9550832e9faa38011448e2b7