### PR TITLE
Add initial DB migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run lint test
+.PHONY: run lint test migrate
 
 run:
 	go run ./cmd/gophermart
@@ -8,3 +8,6 @@ lint:
 
 test:
 	go test ./...
+
+migrate:
+	migrate -path migrations -database $$DATABASE_URI -verbose up

--- a/migrations/0001_init.down.sql
+++ b/migrations/0001_init.down.sql
@@ -1,0 +1,5 @@
+-- +migrate Down
+DROP TABLE IF EXISTS withdrawals;
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS users;
+

--- a/migrations/0001_init.up.sql
+++ b/migrations/0001_init.up.sql
@@ -1,0 +1,25 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS users (
+    id BIGSERIAL PRIMARY KEY,
+    login TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id BIGSERIAL PRIMARY KEY,
+    number TEXT UNIQUE NOT NULL,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    status TEXT NOT NULL,
+    accrual NUMERIC(12,2),
+    uploaded_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS withdrawals (
+    id BIGSERIAL PRIMARY KEY,
+    order_number TEXT UNIQUE NOT NULL,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    amount NUMERIC(12,2) NOT NULL CHECK (amount>0),
+    processed_at TIMESTAMPTZ DEFAULT now()
+);
+


### PR DESCRIPTION
## Summary
- bootstrap SQL schema migrations
- add a Makefile target for applying migrations

## Testing
- `go test ./...`
- `make lint`
- `make migrate` *(fails: `migrate` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c2359969c832e9ad8ad3e83898715