### PR TITLE
Add bcrypt password utilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,13 @@ module github.com/Hobrus/gophermarket
 go 1.23.1
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
+	github.com/rs/zerolog v1.34.0
+	golang.org/x/crypto v0.40.0
+)
+
+require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	github.com/rs/zerolog v1.34.0 // indirect
-	golang.org/x/sys v0.12.0 // indirect
+	golang.org/x/sys v0.34.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,10 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+golang.org/x/crypto v0.40.0 h1:r4x+VvoG5Fm+eJcxMaY8CQM7Lb0l1lsmjGBQ6s8BfKM=
+golang.org/x/crypto v0.40.0/go.mod h1:Qr1vMER5WyS2dfPHAlsOj01wgLbsyWtFn/aY+5+ZdxY=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/pkg/crypto/password.go
+++ b/pkg/crypto/password.go
@@ -1,0 +1,18 @@
+package crypto
+
+import "golang.org/x/crypto/bcrypt"
+
+// HashPassword hashes the raw password using bcrypt with cost 12.
+func HashPassword(raw string) (string, error) {
+	hashed, err := bcrypt.GenerateFromPassword([]byte(raw), 12)
+	if err != nil {
+		return "", err
+	}
+	return string(hashed), nil
+}
+
+// ComparePassword compares a bcrypt hashed password with its possible plaintext equivalent.
+// Returns an error if they do not match.
+func ComparePassword(hash, raw string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(raw))
+}

--- a/pkg/crypto/password_test.go
+++ b/pkg/crypto/password_test.go
@@ -1,0 +1,25 @@
+package crypto
+
+import "testing"
+
+func TestHashAndComparePassword_Success(t *testing.T) {
+	raw := "secret"
+	hash, err := HashPassword(raw)
+	if err != nil {
+		t.Fatalf("unexpected error hashing: %v", err)
+	}
+	if err := ComparePassword(hash, raw); err != nil {
+		t.Errorf("passwords should match: %v", err)
+	}
+}
+
+func TestHashAndComparePassword_Fail(t *testing.T) {
+	raw := "secret"
+	hash, err := HashPassword(raw)
+	if err != nil {
+		t.Fatalf("unexpected error hashing: %v", err)
+	}
+	if err := ComparePassword(hash, "wrong"); err == nil {
+		t.Errorf("expected mismatch error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- add password hashing helpers using bcrypt
- test successful and failing comparisons
- update module dependencies

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c23b8ab14832ebc53cce558ca7e73