### PR TITLE
Add JWT middleware

### DIFF
--- a/internal/delivery/http/middleware_jwt.go
+++ b/internal/delivery/http/middleware_jwt.go
@@ -1,0 +1,60 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ctxKey is context key type for storing values.
+type ctxKey string
+
+const userIDKey ctxKey = "user_id"
+
+// JWT parses AuthToken cookie and validates JWT.
+// On success user id is stored in request context.
+func JWT(secret []byte) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			c, err := r.Cookie("AuthToken")
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			token, err := jwt.Parse(c.Value, func(t *jwt.Token) (interface{}, error) {
+				if t.Method.Alg() != jwt.SigningMethodHS256.Alg() {
+					return nil, errors.New("unexpected signing method")
+				}
+				return secret, nil
+			})
+			if err != nil {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			claims, ok := token.Claims.(jwt.MapClaims)
+			if !ok || !token.Valid {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			sub, ok := claims["sub"].(float64)
+			if !ok {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			ctx := context.WithValue(r.Context(), userIDKey, int64(sub))
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// UserIDFromCtx extracts user id from context.
+func UserIDFromCtx(ctx context.Context) (int64, bool) {
+	if ctx == nil {
+		return 0, false
+	}
+	id, ok := ctx.Value(userIDKey).(int64)
+	return id, ok
+}

--- a/internal/delivery/http/middleware_jwt_test.go
+++ b/internal/delivery/http/middleware_jwt_test.go
@@ -1,0 +1,63 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestJWT_NoToken(t *testing.T) {
+	handlerCalled := false
+	mw := JWT([]byte("secret"))
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if handlerCalled {
+		t.Fatal("handler should not be called")
+	}
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestJWT_WithToken(t *testing.T) {
+	var gotID int64
+	mw := JWT([]byte("secret"))
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := UserIDFromCtx(r.Context())
+		if !ok {
+			t.Fatal("user id missing")
+		}
+		gotID = id
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": int64(42),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	tokenStr, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "AuthToken", Value: tokenStr})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+	if gotID != 42 {
+		t.Fatalf("expected id 42, got %d", gotID)
+	}
+}


### PR DESCRIPTION
## Summary
- add JWT middleware parsing AuthToken cookie
- add helper to retrieve user ID from context
- test middleware behavior with and without a token

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c46531cac832e891f7857a7473a0c