### PR TITLE
Add auth handlers with chi router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Hobrus/gophermarket
 go 1.23.1
 
 require (
+	github.com/go-chi/chi/v5 v5.2.2
 	github.com/golang-jwt/jwt/v5 v5.2.3
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.5

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/delivery/http/auth.go
+++ b/internal/delivery/http/auth.go
@@ -1,0 +1,89 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+// AuthService defines methods required for user authentication.
+type AuthService interface {
+	Register(ctx context.Context, login, password string) (string, error)
+	Login(ctx context.Context, login, password string) (string, error)
+}
+
+type credentials struct {
+	Login    string `json:"login"`
+	Password string `json:"password"`
+}
+
+// NewRouter creates chi router with authentication endpoints.
+func NewRouter(auth AuthService) http.Handler {
+	r := chi.NewRouter()
+	r.Post("/api/user/register", register(auth))
+	r.Post("/api/user/login", login(auth))
+	return r
+}
+
+func register(auth AuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var creds credentials
+		if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		token, err := auth.Register(r.Context(), creds.Login, creds.Password)
+		if err != nil {
+			switch {
+			case errors.Is(err, domain.ErrConflictSelf):
+				w.WriteHeader(http.StatusConflict)
+			case err.Error() == "login too short":
+				w.WriteHeader(http.StatusBadRequest)
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     "AuthToken",
+			Value:    token,
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   true,
+		})
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func login(auth AuthService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var creds credentials
+		if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		token, err := auth.Login(r.Context(), creds.Login, creds.Password)
+		if err != nil {
+			switch {
+			case errors.Is(err, domain.ErrNotFound), err.Error() == "invalid credentials":
+				w.WriteHeader(http.StatusUnauthorized)
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     "AuthToken",
+			Value:    token,
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   true,
+		})
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/internal/delivery/http/auth_test.go
+++ b/internal/delivery/http/auth_test.go
@@ -1,0 +1,132 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+type stubAuth struct {
+	registerFunc func(ctx context.Context, login, password string) (string, error)
+	loginFunc    func(ctx context.Context, login, password string) (string, error)
+}
+
+func (s *stubAuth) Register(ctx context.Context, login, password string) (string, error) {
+	return s.registerFunc(ctx, login, password)
+}
+
+func (s *stubAuth) Login(ctx context.Context, login, password string) (string, error) {
+	return s.loginFunc(ctx, login, password)
+}
+
+func TestRegister_Success(t *testing.T) {
+	auth := &stubAuth{registerFunc: func(ctx context.Context, login, password string) (string, error) {
+		if login != "user" || password != "pass" {
+			t.Fatalf("unexpected args %s %s", login, password)
+		}
+		return "token", nil
+	}}
+	router := NewRouter(auth)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/register", bytes.NewBufferString(`{"login":"user","password":"pass"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+	var c *http.Cookie
+	for _, ck := range w.Result().Cookies() {
+		if ck.Name == "AuthToken" {
+			c = ck
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("cookie missing")
+	}
+	if c.Value != "token" || !c.HttpOnly || !c.Secure || c.Path != "/" {
+		t.Fatal("cookie properties incorrect")
+	}
+}
+
+func TestRegister_Conflict(t *testing.T) {
+	auth := &stubAuth{registerFunc: func(ctx context.Context, login, password string) (string, error) {
+		return "", domain.ErrConflictSelf
+	}}
+	router := NewRouter(auth)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/register", bytes.NewBufferString(`{"login":"a","password":"b"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestRegister_BadRequest(t *testing.T) {
+	auth := &stubAuth{registerFunc: func(ctx context.Context, login, password string) (string, error) {
+		return "", errors.New("should not be called")
+	}}
+	router := NewRouter(auth)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/register", bytes.NewBufferString("{"))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestLogin_Unauthorized(t *testing.T) {
+	auth := &stubAuth{loginFunc: func(ctx context.Context, login, password string) (string, error) {
+		return "", errors.New("invalid credentials")
+	}}
+	router := NewRouter(auth)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/login", bytes.NewBufferString(`{"login":"u","password":"p"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestLogin_Success(t *testing.T) {
+	auth := &stubAuth{loginFunc: func(ctx context.Context, login, password string) (string, error) {
+		if login != "user" || password != "pass" {
+			t.Fatalf("unexpected args %s %s", login, password)
+		}
+		return "tok", nil
+	}}
+	router := NewRouter(auth)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/login", bytes.NewBufferString(`{"login":"user","password":"pass"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+	var c *http.Cookie
+	for _, ck := range w.Result().Cookies() {
+		if ck.Name == "AuthToken" {
+			c = ck
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("cookie missing")
+	}
+	if c.Value != "tok" || !c.HttpOnly || !c.Secure || c.Path != "/" {
+		t.Fatal("cookie properties incorrect")
+	}
+}


### PR DESCRIPTION
## Summary
- implement AuthService interface-based HTTP handlers
- use chi router for /api/user/register and /api/user/login
- set secure AuthToken cookie on successful auth
- add unit tests for the new handlers
- tidy modules for chi dependency

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbd3f8580832e86b82e98cfbf529f