### PR TITLE
Add order upload endpoint with tests

### DIFF
--- a/internal/delivery/http/order.go
+++ b/internal/delivery/http/order.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Hobrus/gophermarket/pkg/luhn"
+)
+
+// OrderService defines methods required for order operations.
+type OrderService interface {
+	Add(ctx context.Context, userID int64, number string) (errConflictSelf, errConflictOther, err error)
+}
+
+// NewOrdersRouter creates router with order endpoints.
+func NewOrdersRouter(svc OrderService) http.Handler {
+	r := chi.NewRouter()
+	r.Post("/api/user/orders", uploadOrder(svc))
+	return r
+}
+
+func uploadOrder(svc OrderService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := UserIDFromCtx(r.Context())
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		var reader io.Reader = r.Body
+		if r.Header.Get("Content-Encoding") == "gzip" {
+			gz, err := gzip.NewReader(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			defer gz.Close()
+			reader = gz
+		}
+		body, err := io.ReadAll(reader)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		number := strings.TrimSpace(string(body))
+		if !luhn.IsValid(number) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return
+		}
+		errSelf, errOther, err := svc.Add(r.Context(), userID, number)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if errSelf != nil {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if errOther != nil {
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}
+}

--- a/internal/delivery/http/order_test.go
+++ b/internal/delivery/http/order_test.go
@@ -1,0 +1,145 @@
+package http
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+type stubOrderService struct {
+	addFunc func(ctx context.Context, userID int64, number string) (error, error, error)
+}
+
+func (s *stubOrderService) Add(ctx context.Context, userID int64, number string) (error, error, error) {
+	return s.addFunc(ctx, userID, number)
+}
+
+func TestUploadOrder(t *testing.T) {
+	validNum := "79927398713"
+	tests := []struct {
+		name       string
+		user       bool
+		body       string
+		gzip       bool
+		noCompress bool
+		addFn      func(ctx context.Context, userID int64, number string) (error, error, error)
+		status     int
+	}{
+		{
+			name:   "unauthorized",
+			user:   false,
+			status: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid number",
+			user: true,
+			body: "123",
+			addFn: func(ctx context.Context, userID int64, number string) (error, error, error) {
+				t.Errorf("should not call add")
+				return nil, nil, nil
+			},
+			status: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "conflict self",
+			user: true,
+			body: validNum,
+			addFn: func(ctx context.Context, userID int64, number string) (error, error, error) {
+				if number != validNum || userID != 1 {
+					t.Fatalf("unexpected args")
+				}
+				return domain.ErrConflictSelf, nil, nil
+			},
+			status: http.StatusOK,
+		},
+		{
+			name: "conflict other",
+			user: true,
+			body: validNum,
+			addFn: func(ctx context.Context, userID int64, number string) (error, error, error) {
+				return nil, domain.ErrConflictOther, nil
+			},
+			status: http.StatusConflict,
+		},
+		{
+			name: "service error",
+			user: true,
+			body: validNum,
+			addFn: func(ctx context.Context, userID int64, number string) (error, error, error) {
+				return nil, nil, errors.New("fail")
+			},
+			status: http.StatusInternalServerError,
+		},
+		{
+			name: "success",
+			user: true,
+			body: validNum,
+			addFn: func(ctx context.Context, userID int64, number string) (error, error, error) {
+				if number != validNum || userID != 1 {
+					t.Fatalf("unexpected args")
+				}
+				return nil, nil, nil
+			},
+			status: http.StatusAccepted,
+		},
+		{
+			name: "gzip",
+			user: true,
+			body: validNum,
+			gzip: true,
+			addFn: func(ctx context.Context, userID int64, number string) (error, error, error) {
+				if number != validNum {
+					t.Fatalf("unexpected num %s", number)
+				}
+				return nil, nil, nil
+			},
+			status: http.StatusAccepted,
+		},
+		{
+			name:       "bad gzip",
+			user:       true,
+			gzip:       true,
+			noCompress: true,
+			body:       "notgzip",
+			addFn: func(ctx context.Context, userID int64, number string) (error, error, error) {
+				t.Errorf("should not call add")
+				return nil, nil, nil
+			},
+			status: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		svc := &stubOrderService{addFunc: tt.addFn}
+		router := NewOrdersRouter(svc)
+
+		var buf bytes.Buffer
+		if tt.gzip && !tt.noCompress {
+			gz := gzip.NewWriter(&buf)
+			io.WriteString(gz, tt.body)
+			gz.Close()
+		} else {
+			buf.WriteString(tt.body)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/user/orders", &buf)
+		if tt.gzip {
+			req.Header.Set("Content-Encoding", "gzip")
+		}
+		if tt.user {
+			req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
+		}
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Result().StatusCode != tt.status {
+			t.Errorf("%s: expected %d, got %d", tt.name, tt.status, w.Result().StatusCode)
+		}
+	}
+}

--- a/internal/service/order.go
+++ b/internal/service/order.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Hobrus/gophermarket/internal/repository"
+)
+
+// OrderService provides order-related operations.
+type OrderService struct {
+	repo repository.OrderRepo
+}
+
+// NewOrderService creates a new OrderService instance.
+func NewOrderService(repo repository.OrderRepo) *OrderService {
+	return &OrderService{repo: repo}
+}
+
+// Add registers a new order with status NEW.
+func (s *OrderService) Add(ctx context.Context, userID int64, number string) (errConflictSelf, errConflictOther, err error) {
+	return s.repo.Add(ctx, number, userID, "NEW")
+}

--- a/internal/service/order_test.go
+++ b/internal/service/order_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+type stubOrderRepo struct {
+	addFunc func(ctx context.Context, num string, userID int64, status string) (error, error, error)
+}
+
+func (s *stubOrderRepo) Add(ctx context.Context, num string, userID int64, status string) (error, error, error) {
+	if s.addFunc != nil {
+		return s.addFunc(ctx, num, userID, status)
+	}
+	return nil, nil, nil
+}
+
+func (s *stubOrderRepo) ListByUser(ctx context.Context, userID int64) ([]domain.Order, error) {
+	return nil, nil
+}
+func (s *stubOrderRepo) GetUnprocessed(ctx context.Context, limit int) ([]domain.Order, error) {
+	return nil, nil
+}
+func (s *stubOrderRepo) UpdateStatus(ctx context.Context, num, status string, accrual *decimal.Decimal) error {
+	return nil
+}
+
+func TestOrderService_Add(t *testing.T) {
+	repo := &stubOrderRepo{addFunc: func(ctx context.Context, num string, userID int64, status string) (error, error, error) {
+		if num != "123" || userID != 1 || status != "NEW" {
+			t.Fatalf("unexpected args %s %d %s", num, userID, status)
+		}
+		return nil, nil, nil
+	}}
+	svc := NewOrderService(repo)
+
+	if errSelf, errOther, err := svc.Add(context.Background(), 1, "123"); errSelf != nil || errOther != nil || err != nil {
+		t.Fatalf("unexpected return %v %v %v", errSelf, errOther, err)
+	}
+}
+
+func TestOrderService_AddConflict(t *testing.T) {
+	repo := &stubOrderRepo{addFunc: func(ctx context.Context, num string, userID int64, status string) (error, error, error) {
+		return domain.ErrConflictSelf, nil, nil
+	}}
+	svc := NewOrderService(repo)
+
+	errSelf, errOther, err := svc.Add(context.Background(), 1, "123")
+	if !errors.Is(errSelf, domain.ErrConflictSelf) || errOther != nil || err != nil {
+		t.Fatalf("unexpected errors %v %v %v", errSelf, errOther, err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `OrderService` with `Add` logic
- add `/api/user/orders` handler with gzip support
- cover order upload handler with extensive table-driven tests

## Testing
- `go test ./internal/delivery/http -run TestUploadOrder -v`
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbeba5a34832e98467dd4dac5a566