### PR TITLE
Implement balance handler and service

### DIFF
--- a/internal/delivery/http/balance.go
+++ b/internal/delivery/http/balance.go
@@ -1,0 +1,39 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/shopspring/decimal"
+)
+
+// BalanceService defines methods required to obtain user balance.
+type BalanceService interface {
+	GetBalance(ctx context.Context, userID int64) (decimal.Decimal, decimal.Decimal, error)
+}
+
+func balance(balanceSvc BalanceService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := UserIDFromCtx(r.Context())
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		current, withdrawn, err := balanceSvc.GetBalance(r.Context(), userID)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		resp := struct {
+			Current   float64 `json:"current"`
+			Withdrawn float64 `json:"withdrawn"`
+		}{
+			Current:   current.InexactFloat64(),
+			Withdrawn: withdrawn.InexactFloat64(),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/internal/delivery/http/balance_test.go
+++ b/internal/delivery/http/balance_test.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+type stubBalanceSvc struct {
+	getBalanceFunc func(ctx context.Context, userID int64) (decimal.Decimal, decimal.Decimal, error)
+}
+
+func (s *stubBalanceSvc) GetBalance(ctx context.Context, userID int64) (decimal.Decimal, decimal.Decimal, error) {
+	return s.getBalanceFunc(ctx, userID)
+}
+
+func TestBalance(t *testing.T) {
+	svc := &stubBalanceSvc{getBalanceFunc: func(ctx context.Context, userID int64) (decimal.Decimal, decimal.Decimal, error) {
+		if userID != 1 {
+			t.Fatalf("unexpected userID %d", userID)
+		}
+		return decimal.NewFromInt(7), decimal.NewFromInt(3), nil
+	}}
+	h := balance(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/balance", nil)
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+	var resp struct {
+		Current   float64 `json:"current"`
+		Withdrawn float64 `json:"withdrawn"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Current != 7 || resp.Withdrawn != 3 {
+		t.Fatalf("unexpected response %+v", resp)
+	}
+}
+
+func TestBalance_Zero(t *testing.T) {
+	svc := &stubBalanceSvc{getBalanceFunc: func(ctx context.Context, userID int64) (decimal.Decimal, decimal.Decimal, error) {
+		return decimal.Zero, decimal.Zero, nil
+	}}
+	h := balance(svc)
+	req := httptest.NewRequest(http.MethodGet, "/api/user/balance", nil)
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(5)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+	var resp struct {
+		Current   float64 `json:"current"`
+		Withdrawn float64 `json:"withdrawn"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Current != 0 || resp.Withdrawn != 0 {
+		t.Fatalf("unexpected response %+v", resp)
+	}
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -29,6 +29,8 @@ type OrderRepo interface {
 	GetUnprocessed(ctx context.Context, limit int) ([]domain.Order, error)
 	// UpdateStatus updates order status and optional accrual.
 	UpdateStatus(ctx context.Context, num, status string, accrual *decimal.Decimal) error
+	// SumAccrualByUser returns total accrual for processed orders of user.
+	SumAccrualByUser(ctx context.Context, userID int64) (decimal.Decimal, error)
 }
 
 // WithdrawalRepo accesses withdrawals storage.

--- a/internal/service/balance.go
+++ b/internal/service/balance.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Hobrus/gophermarket/internal/repository"
+)
+
+// BalanceService provides user balance information.
+type BalanceService struct {
+	orders      repository.OrderRepo
+	withdrawals repository.WithdrawalRepo
+}
+
+// NewBalanceService creates a new BalanceService.
+func NewBalanceService(o repository.OrderRepo, w repository.WithdrawalRepo) *BalanceService {
+	return &BalanceService{orders: o, withdrawals: w}
+}
+
+// GetBalance returns current balance and total withdrawn for user.
+func (s *BalanceService) GetBalance(ctx context.Context, userID int64) (decimal.Decimal, decimal.Decimal, error) {
+	accrual, err := s.orders.SumAccrualByUser(ctx, userID)
+	if err != nil {
+		return decimal.Zero, decimal.Zero, err
+	}
+	withdrawn, err := s.withdrawals.SumByUser(ctx, userID)
+	if err != nil {
+		return decimal.Zero, decimal.Zero, err
+	}
+	return accrual.Sub(withdrawn), withdrawn, nil
+}

--- a/internal/service/balance_test.go
+++ b/internal/service/balance_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+type stubOrderRepo struct {
+	sumFunc func(ctx context.Context, userID int64) (decimal.Decimal, error)
+}
+
+func (s *stubOrderRepo) Add(ctx context.Context, num string, userID int64, status string) (error, error, error) {
+	return nil, nil, nil
+}
+func (s *stubOrderRepo) ListByUser(ctx context.Context, userID int64) ([]domain.Order, error) {
+	return nil, nil
+}
+func (s *stubOrderRepo) GetUnprocessed(ctx context.Context, limit int) ([]domain.Order, error) {
+	return nil, nil
+}
+func (s *stubOrderRepo) UpdateStatus(ctx context.Context, num, status string, accrual *decimal.Decimal) error {
+	return nil
+}
+func (s *stubOrderRepo) SumAccrualByUser(ctx context.Context, userID int64) (decimal.Decimal, error) {
+	return s.sumFunc(ctx, userID)
+}
+
+type stubWithdrawalRepo struct {
+	sumFunc func(ctx context.Context, userID int64) (decimal.Decimal, error)
+}
+
+func (s *stubWithdrawalRepo) Create(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
+	return nil
+}
+func (s *stubWithdrawalRepo) ListByUser(ctx context.Context, userID int64) ([]domain.Withdrawal, error) {
+	return nil, nil
+}
+func (s *stubWithdrawalRepo) SumByUser(ctx context.Context, userID int64) (decimal.Decimal, error) {
+	return s.sumFunc(ctx, userID)
+}
+
+func TestBalanceService_GetBalance(t *testing.T) {
+	or := &stubOrderRepo{sumFunc: func(ctx context.Context, userID int64) (decimal.Decimal, error) {
+		if userID != 1 {
+			t.Fatalf("unexpected userID %d", userID)
+		}
+		return decimal.NewFromInt(10), nil
+	}}
+	wr := &stubWithdrawalRepo{sumFunc: func(ctx context.Context, userID int64) (decimal.Decimal, error) {
+		if userID != 1 {
+			t.Fatalf("unexpected userID %d", userID)
+		}
+		return decimal.NewFromInt(3), nil
+	}}
+	svc := NewBalanceService(or, wr)
+
+	current, withdrawn, err := svc.GetBalance(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if !current.Equal(decimal.NewFromInt(7)) {
+		t.Errorf("unexpected current %s", current)
+	}
+	if !withdrawn.Equal(decimal.NewFromInt(3)) {
+		t.Errorf("unexpected withdrawn %s", withdrawn)
+	}
+}
+
+func TestBalanceService_Zero(t *testing.T) {
+	svc := NewBalanceService(&stubOrderRepo{sumFunc: func(ctx context.Context, userID int64) (decimal.Decimal, error) {
+		return decimal.Zero, nil
+	}}, &stubWithdrawalRepo{sumFunc: func(ctx context.Context, userID int64) (decimal.Decimal, error) {
+		return decimal.Zero, nil
+	}})
+
+	current, withdrawn, err := svc.GetBalance(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if !current.Equal(decimal.Zero) || !withdrawn.Equal(decimal.Zero) {
+		t.Fatalf("expected zeros, got %s %s", current, withdrawn)
+	}
+}

--- a/internal/storage/postgres/repo.go
+++ b/internal/storage/postgres/repo.go
@@ -1,24 +1,24 @@
 package postgres
 
 import (
-    "context"
-    "errors"
-    "time"
+	"context"
+	"errors"
+	"time"
 
-    "github.com/jackc/pgx/v5"
-    "github.com/jackc/pgx/v5/pgconn"
-    "github.com/jackc/pgx/v5/pgxpool"
-    "github.com/shopspring/decimal"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
 
-    "github.com/Hobrus/gophermarket/internal/domain"
-    "github.com/Hobrus/gophermarket/internal/repository"
+	"github.com/Hobrus/gophermarket/internal/domain"
+	"github.com/Hobrus/gophermarket/internal/repository"
 )
 
 const timeout = 5 * time.Second
 
 // New creates repositories backed by pgx pool.
 func New(pool *pgxpool.Pool) (repository.UserRepo, repository.OrderRepo, repository.WithdrawalRepo) {
-    return &userRepo{pool}, &orderRepo{pool}, &withdrawalRepo{pool}
+	return &userRepo{pool}, &orderRepo{pool}, &withdrawalRepo{pool}
 }
 
 type userRepo struct{ pool *pgxpool.Pool }
@@ -28,245 +28,264 @@ type orderRepo struct{ pool *pgxpool.Pool }
 type withdrawalRepo struct{ pool *pgxpool.Pool }
 
 func beginTx(ctx context.Context, pool *pgxpool.Pool) (pgx.Tx, context.Context, context.CancelFunc, error) {
-    ctx, cancel := context.WithTimeout(ctx, timeout)
-    tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
-    if err != nil {
-        cancel()
-        return nil, nil, nil, err
-    }
-    return tx, ctx, cancel, nil
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		cancel()
+		return nil, nil, nil, err
+	}
+	return tx, ctx, cancel, nil
 }
 
 func isUniqueViolation(err error) bool {
-    var pgErr *pgconn.PgError
-    if errors.As(err, &pgErr) {
-        return pgErr.Code == "23505"
-    }
-    return false
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505"
+	}
+	return false
 }
 
 // -- UserRepo implementation --
 
 func (r *userRepo) Create(ctx context.Context, login, hash string) (int64, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return 0, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return 0, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    var id int64
-    err = tx.QueryRow(ctx, `INSERT INTO users (login, password_hash) VALUES ($1,$2) RETURNING id`, login, hash).Scan(&id)
-    if err != nil {
-        if isUniqueViolation(err) {
-            return 0, domain.ErrConflictSelf
-        }
-        return 0, err
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return 0, err
-    }
-    return id, nil
+	var id int64
+	err = tx.QueryRow(ctx, `INSERT INTO users (login, password_hash) VALUES ($1,$2) RETURNING id`, login, hash).Scan(&id)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return 0, domain.ErrConflictSelf
+		}
+		return 0, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return id, nil
 }
 
 func (r *userRepo) GetByLogin(ctx context.Context, login string) (domain.User, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return domain.User{}, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return domain.User{}, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    var u domain.User
-    err = tx.QueryRow(ctx, `SELECT id, login, password_hash FROM users WHERE login=$1`, login).
-        Scan(&u.ID, &u.Login, &u.PasswordHash)
-    if errors.Is(err, pgx.ErrNoRows) {
-        return domain.User{}, domain.ErrNotFound
-    }
-    if err != nil {
-        return domain.User{}, err
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return domain.User{}, err
-    }
-    return u, nil
+	var u domain.User
+	err = tx.QueryRow(ctx, `SELECT id, login, password_hash FROM users WHERE login=$1`, login).
+		Scan(&u.ID, &u.Login, &u.PasswordHash)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.User{}, domain.ErrNotFound
+	}
+	if err != nil {
+		return domain.User{}, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return domain.User{}, err
+	}
+	return u, nil
 }
 
 // -- OrderRepo implementation --
 
 func (r *orderRepo) Add(ctx context.Context, num string, userID int64, status string) (error, error, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return nil, nil, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    _, err = tx.Exec(ctx, `INSERT INTO orders (number, user_id, status) VALUES ($1,$2,$3)`, num, userID, status)
-    if err != nil {
-        if isUniqueViolation(err) {
-            var existing int64
-            err2 := tx.QueryRow(ctx, `SELECT user_id FROM orders WHERE number=$1`, num).Scan(&existing)
-            if err2 != nil {
-                return nil, nil, err2
-            }
-            if existing == userID {
-                return domain.ErrConflictSelf, nil, nil
-            }
-            return nil, domain.ErrConflictOther, nil
-        }
-        return nil, nil, err
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return nil, nil, err
-    }
-    return nil, nil, nil
+	_, err = tx.Exec(ctx, `INSERT INTO orders (number, user_id, status) VALUES ($1,$2,$3)`, num, userID, status)
+	if err != nil {
+		if isUniqueViolation(err) {
+			var existing int64
+			err2 := tx.QueryRow(ctx, `SELECT user_id FROM orders WHERE number=$1`, num).Scan(&existing)
+			if err2 != nil {
+				return nil, nil, err2
+			}
+			if existing == userID {
+				return domain.ErrConflictSelf, nil, nil
+			}
+			return nil, domain.ErrConflictOther, nil
+		}
+		return nil, nil, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return nil, nil, err
+	}
+	return nil, nil, nil
 }
 
 func (r *orderRepo) ListByUser(ctx context.Context, userID int64) ([]domain.Order, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return nil, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE user_id=$1 ORDER BY uploaded_at DESC`, userID)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE user_id=$1 ORDER BY uploaded_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var orders []domain.Order
-    for rows.Next() {
-        var o domain.Order
-        err = rows.Scan(&o.Number, &o.UserID, &o.Status, &o.Accrual, &o.UploadedAt)
-        if err != nil {
-            return nil, err
-        }
-        orders = append(orders, o)
-    }
-    if rows.Err() != nil {
-        return nil, rows.Err()
-    }
+	var orders []domain.Order
+	for rows.Next() {
+		var o domain.Order
+		err = rows.Scan(&o.Number, &o.UserID, &o.Status, &o.Accrual, &o.UploadedAt)
+		if err != nil {
+			return nil, err
+		}
+		orders = append(orders, o)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
 
-    if err = tx.Commit(ctx); err != nil {
-        return nil, err
-    }
-    return orders, nil
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return orders, nil
 }
 
 func (r *orderRepo) GetUnprocessed(ctx context.Context, limit int) ([]domain.Order, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return nil, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE status IN ('NEW','PROCESSING') ORDER BY uploaded_at LIMIT $1`, limit)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE status IN ('NEW','PROCESSING') ORDER BY uploaded_at LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var orders []domain.Order
-    for rows.Next() {
-        var o domain.Order
-        err = rows.Scan(&o.Number, &o.UserID, &o.Status, &o.Accrual, &o.UploadedAt)
-        if err != nil {
-            return nil, err
-        }
-        orders = append(orders, o)
-    }
-    if rows.Err() != nil {
-        return nil, rows.Err()
-    }
+	var orders []domain.Order
+	for rows.Next() {
+		var o domain.Order
+		err = rows.Scan(&o.Number, &o.UserID, &o.Status, &o.Accrual, &o.UploadedAt)
+		if err != nil {
+			return nil, err
+		}
+		orders = append(orders, o)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
 
-    if err = tx.Commit(ctx); err != nil {
-        return nil, err
-    }
-    return orders, nil
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return orders, nil
 }
 
 func (r *orderRepo) UpdateStatus(ctx context.Context, num, status string, accrual *decimal.Decimal) error {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    _, err = tx.Exec(ctx, `UPDATE orders SET status=$2, accrual=$3 WHERE number=$1`, num, status, accrual)
-    if err != nil {
-        return err
-    }
-    return tx.Commit(ctx)
+	_, err = tx.Exec(ctx, `UPDATE orders SET status=$2, accrual=$3 WHERE number=$1`, num, status, accrual)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (r *orderRepo) SumAccrualByUser(ctx context.Context, userID int64) (decimal.Decimal, error) {
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
+
+	var sum decimal.Decimal
+	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(accrual),0) FROM orders WHERE user_id=$1 AND status='PROCESSED'`, userID).Scan(&sum)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return decimal.Zero, err
+	}
+	return sum, nil
 }
 
 // -- WithdrawalRepo implementation --
 
 func (r *withdrawalRepo) Create(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    _, err = tx.Exec(ctx, `INSERT INTO withdrawals (order_number, user_id, amount) VALUES ($1,$2,$3)`, num, userID, amount)
-    if err != nil {
-        return err
-    }
-    return tx.Commit(ctx)
+	_, err = tx.Exec(ctx, `INSERT INTO withdrawals (order_number, user_id, amount) VALUES ($1,$2,$3)`, num, userID, amount)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (r *withdrawalRepo) ListByUser(ctx context.Context, userID int64) ([]domain.Withdrawal, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return nil, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    rows, err := tx.Query(ctx, `SELECT order_number, user_id, amount, processed_at FROM withdrawals WHERE user_id=$1 ORDER BY processed_at DESC`, userID)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	rows, err := tx.Query(ctx, `SELECT order_number, user_id, amount, processed_at FROM withdrawals WHERE user_id=$1 ORDER BY processed_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var res []domain.Withdrawal
-    for rows.Next() {
-        var w domain.Withdrawal
-        if err = rows.Scan(&w.Number, &w.UserID, &w.Amount, &w.ProcessedAt); err != nil {
-            return nil, err
-        }
-        res = append(res, w)
-    }
-    if rows.Err() != nil {
-        return nil, rows.Err()
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return nil, err
-    }
-    return res, nil
+	var res []domain.Withdrawal
+	for rows.Next() {
+		var w domain.Withdrawal
+		if err = rows.Scan(&w.Number, &w.UserID, &w.Amount, &w.ProcessedAt); err != nil {
+			return nil, err
+		}
+		res = append(res, w)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 func (r *withdrawalRepo) SumByUser(ctx context.Context, userID int64) (decimal.Decimal, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return decimal.Zero, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    var sum decimal.Decimal
-    err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(amount),0) FROM withdrawals WHERE user_id=$1`, userID).Scan(&sum)
-    if err != nil {
-        return decimal.Zero, err
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return decimal.Zero, err
-    }
-    return sum, nil
+	var sum decimal.Decimal
+	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(amount),0) FROM withdrawals WHERE user_id=$1`, userID).Scan(&sum)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return decimal.Zero, err
+	}
+	return sum, nil
 }

--- a/internal/storage/postgres/repo_test.go
+++ b/internal/storage/postgres/repo_test.go
@@ -1,149 +1,157 @@
 package postgres
 
 import (
-    "context"
-    "errors"
-    "fmt"
-    "testing"
-    "time"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
 
-    "github.com/shopspring/decimal"
-    "github.com/testcontainers/testcontainers-go"
-    "github.com/testcontainers/testcontainers-go/wait"
-    "github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 
-    "github.com/Hobrus/gophermarket/internal/domain"
+	"github.com/Hobrus/gophermarket/internal/domain"
 )
 
 func setupPostgres(t *testing.T) (*pgxpool.Pool, func()) {
-    t.Helper()
+	t.Helper()
 
-    ctx := context.Background()
-    req := testcontainers.ContainerRequest{
-        Image:        "postgres:15-alpine",
-        Env: map[string]string{
-            "POSTGRES_PASSWORD": "pass",
-            "POSTGRES_USER":     "user",
-            "POSTGRES_DB":       "test",
-        },
-        ExposedPorts: []string{"5432/tcp"},
-        WaitingFor:   wait.ForListeningPort("5432/tcp"),
-    }
+	ctx := context.Background()
+	req := testcontainers.ContainerRequest{
+		Image: "postgres:15-alpine",
+		Env: map[string]string{
+			"POSTGRES_PASSWORD": "pass",
+			"POSTGRES_USER":     "user",
+			"POSTGRES_DB":       "test",
+		},
+		ExposedPorts: []string{"5432/tcp"},
+		WaitingFor:   wait.ForListeningPort("5432/tcp"),
+	}
 
-    container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-        ContainerRequest: req,
-        Started:          true,
-    })
-    if err != nil {
-        t.Fatal(err)
-    }
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    host, err := container.Host(ctx)
-    if err != nil {
-        t.Fatal(err)
-    }
-    port, err := container.MappedPort(ctx, "5432/tcp")
-    if err != nil {
-        t.Fatal(err)
-    }
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := container.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    dsn := fmt.Sprintf("postgres://user:pass@%s:%s/test?sslmode=disable", host, port.Port())
-    pool, err := pgxpool.New(ctx, dsn)
-    if err != nil {
-        t.Fatal(err)
-    }
+	dsn := fmt.Sprintf("postgres://user:pass@%s:%s/test?sslmode=disable", host, port.Port())
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    ctxPing, cancel := context.WithTimeout(ctx, 10*time.Second)
-    defer cancel()
-    if err := pool.Ping(ctxPing); err != nil {
-        t.Fatal(err)
-    }
+	ctxPing, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := pool.Ping(ctxPing); err != nil {
+		t.Fatal(err)
+	}
 
-    if err := applyMigrations(ctx, pool); err != nil {
-        t.Fatal(err)
-    }
+	if err := applyMigrations(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
 
-    return pool, func() {
-        pool.Close()
-        container.Terminate(context.Background())
-    }
+	return pool, func() {
+		pool.Close()
+		container.Terminate(context.Background())
+	}
 }
 
 func TestRepositories(t *testing.T) {
-    pool, teardown := setupPostgres(t)
-    defer teardown()
+	pool, teardown := setupPostgres(t)
+	defer teardown()
 
-    userRepo, orderRepo, withdrawalRepo := New(pool)
+	userRepo, orderRepo, withdrawalRepo := New(pool)
 
-    ctx := context.Background()
+	ctx := context.Background()
 
-    // create user
-    uid, err := userRepo.Create(ctx, "login", "hash")
-    if err != nil {
-        t.Fatalf("create user: %v", err)
-    }
-    if _, err = userRepo.Create(ctx, "login", "hash"); !errors.Is(err, domain.ErrConflictSelf) {
-        t.Fatalf("expected conflict")
-    }
+	// create user
+	uid, err := userRepo.Create(ctx, "login", "hash")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err = userRepo.Create(ctx, "login", "hash"); !errors.Is(err, domain.ErrConflictSelf) {
+		t.Fatalf("expected conflict")
+	}
 
-    u, err := userRepo.GetByLogin(ctx, "login")
-    if err != nil || u.ID != uid {
-        t.Fatalf("get user: %v", err)
-    }
+	u, err := userRepo.GetByLogin(ctx, "login")
+	if err != nil || u.ID != uid {
+		t.Fatalf("get user: %v", err)
+	}
 
-    // orders
-    if errSelf, errOther, err := orderRepo.Add(ctx, "42", uid, "NEW"); err != nil || errSelf != nil || errOther != nil {
-        t.Fatalf("add order: %v %v %v", errSelf, errOther, err)
-    }
+	// orders
+	if errSelf, errOther, err := orderRepo.Add(ctx, "42", uid, "NEW"); err != nil || errSelf != nil || errOther != nil {
+		t.Fatalf("add order: %v %v %v", errSelf, errOther, err)
+	}
 
-    if errSelf, errOther, err := orderRepo.Add(ctx, "42", uid, "NEW"); !errors.Is(errSelf, domain.ErrConflictSelf) || errOther != nil || err != nil {
-        t.Fatalf("expected self conflict")
-    }
+	if errSelf, errOther, err := orderRepo.Add(ctx, "42", uid, "NEW"); !errors.Is(errSelf, domain.ErrConflictSelf) || errOther != nil || err != nil {
+		t.Fatalf("expected self conflict")
+	}
 
-    uid2, err := userRepo.Create(ctx, "other", "hash")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if errSelf, errOther, err := orderRepo.Add(ctx, "42", uid2, "NEW"); !errors.Is(errOther, domain.ErrConflictOther) || errSelf != nil || err != nil {
-        t.Fatalf("expected other conflict")
-    }
+	uid2, err := userRepo.Create(ctx, "other", "hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errSelf, errOther, err := orderRepo.Add(ctx, "42", uid2, "NEW"); !errors.Is(errOther, domain.ErrConflictOther) || errSelf != nil || err != nil {
+		t.Fatalf("expected other conflict")
+	}
 
-    orders, err := orderRepo.ListByUser(ctx, uid)
-    if err != nil || len(orders) != 1 || orders[0].Number != "42" {
-        t.Fatalf("list orders: %v", err)
-    }
+	orders, err := orderRepo.ListByUser(ctx, uid)
+	if err != nil || len(orders) != 1 || orders[0].Number != "42" {
+		t.Fatalf("list orders: %v", err)
+	}
 
-    up, err := orderRepo.GetUnprocessed(ctx, 10)
-    if err != nil || len(up) != 1 {
-        t.Fatalf("get unprocessed: %v", err)
-    }
+	up, err := orderRepo.GetUnprocessed(ctx, 10)
+	if err != nil || len(up) != 1 {
+		t.Fatalf("get unprocessed: %v", err)
+	}
 
-    accrual := decimal.NewFromInt(10)
-    if err := orderRepo.UpdateStatus(ctx, "42", "PROCESSED", &accrual); err != nil {
-        t.Fatalf("update status: %v", err)
-    }
+	accrual := decimal.NewFromInt(10)
+	if err := orderRepo.UpdateStatus(ctx, "42", "PROCESSED", &accrual); err != nil {
+		t.Fatalf("update status: %v", err)
+	}
 
-    up, err = orderRepo.GetUnprocessed(ctx, 10)
-    if err != nil || len(up) != 0 {
-        t.Fatalf("get unprocessed after update: %v", err)
-    }
+	up, err = orderRepo.GetUnprocessed(ctx, 10)
+	if err != nil || len(up) != 0 {
+		t.Fatalf("get unprocessed after update: %v", err)
+	}
 
-    // withdrawals
-    if err := withdrawalRepo.Create(ctx, "w1", uid, decimal.NewFromInt(5)); err != nil {
-        t.Fatalf("withdraw create: %v", err)
-    }
-    if err := withdrawalRepo.Create(ctx, "w2", uid, decimal.NewFromInt(3)); err != nil {
-        t.Fatalf("withdraw create: %v", err)
-    }
+	sumAcc, err := orderRepo.SumAccrualByUser(ctx, uid)
+	if err != nil || !sumAcc.Equal(accrual) {
+		t.Fatalf("sum accrual: %v %s", err, sumAcc)
+	}
+	sumAcc2, err := orderRepo.SumAccrualByUser(ctx, uid2)
+	if err != nil || !sumAcc2.Equal(decimal.Zero) {
+		t.Fatalf("sum accrual for other: %v %s", err, sumAcc2)
+	}
 
-    ws, err := withdrawalRepo.ListByUser(ctx, uid)
-    if err != nil || len(ws) != 2 {
-        t.Fatalf("list withdrawals: %v", err)
-    }
+	// withdrawals
+	if err := withdrawalRepo.Create(ctx, "w1", uid, decimal.NewFromInt(5)); err != nil {
+		t.Fatalf("withdraw create: %v", err)
+	}
+	if err := withdrawalRepo.Create(ctx, "w2", uid, decimal.NewFromInt(3)); err != nil {
+		t.Fatalf("withdraw create: %v", err)
+	}
 
-    sum, err := withdrawalRepo.SumByUser(ctx, uid)
-    if err != nil || !sum.Equal(decimal.NewFromInt(8)) {
-        t.Fatalf("sum withdrawals: %v %s", err, sum)
-    }
+	ws, err := withdrawalRepo.ListByUser(ctx, uid)
+	if err != nil || len(ws) != 2 {
+		t.Fatalf("list withdrawals: %v", err)
+	}
+
+	sum, err := withdrawalRepo.SumByUser(ctx, uid)
+	if err != nil || !sum.Equal(decimal.NewFromInt(8)) {
+		t.Fatalf("sum withdrawals: %v %s", err, sum)
+	}
 }
-


### PR DESCRIPTION
## Summary
- track processed order accruals in repository
- compute user balance via BalanceService
- expose GET `/api/user/balance`
- cover new functionality with tests

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbed58070832e914a3cbaff686e80