### PR TITLE
Implement withdrawal API

### DIFF
--- a/internal/delivery/http/balance.go
+++ b/internal/delivery/http/balance.go
@@ -1,0 +1,58 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+	"github.com/Hobrus/gophermarket/pkg/luhn"
+)
+
+// BalanceService defines methods required for balance operations.
+type BalanceService interface {
+	Withdraw(ctx context.Context, userID int64, order string, amount decimal.Decimal) error
+}
+
+func NewBalanceRouter(s BalanceService) http.Handler {
+	r := chi.NewRouter()
+	r.Post("/api/user/balance/withdraw", withdraw(s))
+	return r
+}
+
+type withdrawRequest struct {
+	Order string          `json:"order"`
+	Sum   decimal.Decimal `json:"sum"`
+}
+
+func withdraw(s BalanceService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req withdrawRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if !luhn.IsValid(req.Order) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return
+		}
+		id, ok := UserIDFromCtx(r.Context())
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if err := s.Withdraw(r.Context(), id, req.Order, req.Sum); err != nil {
+			if errors.Is(err, domain.ErrInsufficientBalance) {
+				w.WriteHeader(http.StatusPaymentRequired)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/internal/delivery/http/balance_test.go
+++ b/internal/delivery/http/balance_test.go
@@ -1,0 +1,77 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+type stubBalance struct {
+	withdrawFunc func(ctx context.Context, userID int64, order string, amount decimal.Decimal) error
+}
+
+func (s *stubBalance) Withdraw(ctx context.Context, userID int64, order string, amount decimal.Decimal) error {
+	return s.withdrawFunc(ctx, userID, order, amount)
+}
+
+func TestWithdraw_Success(t *testing.T) {
+	svc := &stubBalance{withdrawFunc: func(ctx context.Context, userID int64, order string, amount decimal.Decimal) error {
+		if userID != 1 || order != "2377225624" || !amount.Equal(decimal.NewFromInt(751)) {
+			t.Fatalf("unexpected args %d %s %s", userID, order, amount.String())
+		}
+		return nil
+	}}
+	router := NewBalanceRouter(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/balance/withdraw", bytes.NewBufferString(`{"order":"2377225624","sum":751}`))
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestWithdraw_Insufficient(t *testing.T) {
+	svc := &stubBalance{withdrawFunc: func(ctx context.Context, userID int64, order string, amount decimal.Decimal) error {
+		return domain.ErrInsufficientBalance
+	}}
+	router := NewBalanceRouter(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/balance/withdraw", bytes.NewBufferString(`{"order":"2377225624","sum":751}`))
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestWithdraw_InvalidOrder(t *testing.T) {
+	called := false
+	svc := &stubBalance{withdrawFunc: func(ctx context.Context, userID int64, order string, amount decimal.Decimal) error {
+		called = true
+		return nil
+	}}
+	router := NewBalanceRouter(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/balance/withdraw", bytes.NewBufferString(`{"order":"123","sum":751}`))
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", w.Result().StatusCode)
+	}
+	if called {
+		t.Fatal("service should not be called")
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -9,4 +9,6 @@ var (
 	ErrConflictOther = errors.New("conflict: already uploaded by other user")
 	// ErrNotFound is returned when requested entity is not found.
 	ErrNotFound = errors.New("not found")
+	// ErrInsufficientBalance indicates user does not have enough balance for withdrawal.
+	ErrInsufficientBalance = errors.New("insufficient balance")
 )

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -39,4 +39,7 @@ type WithdrawalRepo interface {
 	ListByUser(ctx context.Context, userID int64) ([]domain.Withdrawal, error)
 	// SumByUser returns total amount withdrawn by user.
 	SumByUser(ctx context.Context, userID int64) (decimal.Decimal, error)
+	// Withdraw checks balance and registers withdrawal atomically.
+	// Returns ErrInsufficientBalance if balance is not enough.
+	Withdraw(ctx context.Context, num string, userID int64, amount decimal.Decimal) error
 }

--- a/internal/service/balance.go
+++ b/internal/service/balance.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Hobrus/gophermarket/internal/repository"
+)
+
+// BalanceService provides user balance operations.
+type BalanceService struct {
+	withdrawalRepo repository.WithdrawalRepo
+}
+
+// NewBalanceService creates BalanceService instance.
+func NewBalanceService(w repository.WithdrawalRepo) *BalanceService {
+	return &BalanceService{withdrawalRepo: w}
+}
+
+// Withdraw withdraws loyalty points for user.
+func (s *BalanceService) Withdraw(ctx context.Context, userID int64, order string, amount decimal.Decimal) error {
+	return s.withdrawalRepo.Withdraw(ctx, order, userID, amount)
+}

--- a/internal/storage/postgres/repo.go
+++ b/internal/storage/postgres/repo.go
@@ -1,24 +1,24 @@
 package postgres
 
 import (
-    "context"
-    "errors"
-    "time"
+	"context"
+	"errors"
+	"time"
 
-    "github.com/jackc/pgx/v5"
-    "github.com/jackc/pgx/v5/pgconn"
-    "github.com/jackc/pgx/v5/pgxpool"
-    "github.com/shopspring/decimal"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
 
-    "github.com/Hobrus/gophermarket/internal/domain"
-    "github.com/Hobrus/gophermarket/internal/repository"
+	"github.com/Hobrus/gophermarket/internal/domain"
+	"github.com/Hobrus/gophermarket/internal/repository"
 )
 
 const timeout = 5 * time.Second
 
 // New creates repositories backed by pgx pool.
 func New(pool *pgxpool.Pool) (repository.UserRepo, repository.OrderRepo, repository.WithdrawalRepo) {
-    return &userRepo{pool}, &orderRepo{pool}, &withdrawalRepo{pool}
+	return &userRepo{pool}, &orderRepo{pool}, &withdrawalRepo{pool}
 }
 
 type userRepo struct{ pool *pgxpool.Pool }
@@ -28,245 +28,273 @@ type orderRepo struct{ pool *pgxpool.Pool }
 type withdrawalRepo struct{ pool *pgxpool.Pool }
 
 func beginTx(ctx context.Context, pool *pgxpool.Pool) (pgx.Tx, context.Context, context.CancelFunc, error) {
-    ctx, cancel := context.WithTimeout(ctx, timeout)
-    tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
-    if err != nil {
-        cancel()
-        return nil, nil, nil, err
-    }
-    return tx, ctx, cancel, nil
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		cancel()
+		return nil, nil, nil, err
+	}
+	return tx, ctx, cancel, nil
 }
 
 func isUniqueViolation(err error) bool {
-    var pgErr *pgconn.PgError
-    if errors.As(err, &pgErr) {
-        return pgErr.Code == "23505"
-    }
-    return false
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505"
+	}
+	return false
 }
 
 // -- UserRepo implementation --
 
 func (r *userRepo) Create(ctx context.Context, login, hash string) (int64, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return 0, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return 0, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    var id int64
-    err = tx.QueryRow(ctx, `INSERT INTO users (login, password_hash) VALUES ($1,$2) RETURNING id`, login, hash).Scan(&id)
-    if err != nil {
-        if isUniqueViolation(err) {
-            return 0, domain.ErrConflictSelf
-        }
-        return 0, err
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return 0, err
-    }
-    return id, nil
+	var id int64
+	err = tx.QueryRow(ctx, `INSERT INTO users (login, password_hash) VALUES ($1,$2) RETURNING id`, login, hash).Scan(&id)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return 0, domain.ErrConflictSelf
+		}
+		return 0, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return id, nil
 }
 
 func (r *userRepo) GetByLogin(ctx context.Context, login string) (domain.User, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return domain.User{}, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return domain.User{}, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    var u domain.User
-    err = tx.QueryRow(ctx, `SELECT id, login, password_hash FROM users WHERE login=$1`, login).
-        Scan(&u.ID, &u.Login, &u.PasswordHash)
-    if errors.Is(err, pgx.ErrNoRows) {
-        return domain.User{}, domain.ErrNotFound
-    }
-    if err != nil {
-        return domain.User{}, err
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return domain.User{}, err
-    }
-    return u, nil
+	var u domain.User
+	err = tx.QueryRow(ctx, `SELECT id, login, password_hash FROM users WHERE login=$1`, login).
+		Scan(&u.ID, &u.Login, &u.PasswordHash)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return domain.User{}, domain.ErrNotFound
+	}
+	if err != nil {
+		return domain.User{}, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return domain.User{}, err
+	}
+	return u, nil
 }
 
 // -- OrderRepo implementation --
 
 func (r *orderRepo) Add(ctx context.Context, num string, userID int64, status string) (error, error, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return nil, nil, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    _, err = tx.Exec(ctx, `INSERT INTO orders (number, user_id, status) VALUES ($1,$2,$3)`, num, userID, status)
-    if err != nil {
-        if isUniqueViolation(err) {
-            var existing int64
-            err2 := tx.QueryRow(ctx, `SELECT user_id FROM orders WHERE number=$1`, num).Scan(&existing)
-            if err2 != nil {
-                return nil, nil, err2
-            }
-            if existing == userID {
-                return domain.ErrConflictSelf, nil, nil
-            }
-            return nil, domain.ErrConflictOther, nil
-        }
-        return nil, nil, err
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return nil, nil, err
-    }
-    return nil, nil, nil
+	_, err = tx.Exec(ctx, `INSERT INTO orders (number, user_id, status) VALUES ($1,$2,$3)`, num, userID, status)
+	if err != nil {
+		if isUniqueViolation(err) {
+			var existing int64
+			err2 := tx.QueryRow(ctx, `SELECT user_id FROM orders WHERE number=$1`, num).Scan(&existing)
+			if err2 != nil {
+				return nil, nil, err2
+			}
+			if existing == userID {
+				return domain.ErrConflictSelf, nil, nil
+			}
+			return nil, domain.ErrConflictOther, nil
+		}
+		return nil, nil, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return nil, nil, err
+	}
+	return nil, nil, nil
 }
 
 func (r *orderRepo) ListByUser(ctx context.Context, userID int64) ([]domain.Order, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return nil, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE user_id=$1 ORDER BY uploaded_at DESC`, userID)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE user_id=$1 ORDER BY uploaded_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var orders []domain.Order
-    for rows.Next() {
-        var o domain.Order
-        err = rows.Scan(&o.Number, &o.UserID, &o.Status, &o.Accrual, &o.UploadedAt)
-        if err != nil {
-            return nil, err
-        }
-        orders = append(orders, o)
-    }
-    if rows.Err() != nil {
-        return nil, rows.Err()
-    }
+	var orders []domain.Order
+	for rows.Next() {
+		var o domain.Order
+		err = rows.Scan(&o.Number, &o.UserID, &o.Status, &o.Accrual, &o.UploadedAt)
+		if err != nil {
+			return nil, err
+		}
+		orders = append(orders, o)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
 
-    if err = tx.Commit(ctx); err != nil {
-        return nil, err
-    }
-    return orders, nil
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return orders, nil
 }
 
 func (r *orderRepo) GetUnprocessed(ctx context.Context, limit int) ([]domain.Order, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return nil, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE status IN ('NEW','PROCESSING') ORDER BY uploaded_at LIMIT $1`, limit)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE status IN ('NEW','PROCESSING') ORDER BY uploaded_at LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var orders []domain.Order
-    for rows.Next() {
-        var o domain.Order
-        err = rows.Scan(&o.Number, &o.UserID, &o.Status, &o.Accrual, &o.UploadedAt)
-        if err != nil {
-            return nil, err
-        }
-        orders = append(orders, o)
-    }
-    if rows.Err() != nil {
-        return nil, rows.Err()
-    }
+	var orders []domain.Order
+	for rows.Next() {
+		var o domain.Order
+		err = rows.Scan(&o.Number, &o.UserID, &o.Status, &o.Accrual, &o.UploadedAt)
+		if err != nil {
+			return nil, err
+		}
+		orders = append(orders, o)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
 
-    if err = tx.Commit(ctx); err != nil {
-        return nil, err
-    }
-    return orders, nil
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return orders, nil
 }
 
 func (r *orderRepo) UpdateStatus(ctx context.Context, num, status string, accrual *decimal.Decimal) error {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    _, err = tx.Exec(ctx, `UPDATE orders SET status=$2, accrual=$3 WHERE number=$1`, num, status, accrual)
-    if err != nil {
-        return err
-    }
-    return tx.Commit(ctx)
+	_, err = tx.Exec(ctx, `UPDATE orders SET status=$2, accrual=$3 WHERE number=$1`, num, status, accrual)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 // -- WithdrawalRepo implementation --
 
 func (r *withdrawalRepo) Create(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    _, err = tx.Exec(ctx, `INSERT INTO withdrawals (order_number, user_id, amount) VALUES ($1,$2,$3)`, num, userID, amount)
-    if err != nil {
-        return err
-    }
-    return tx.Commit(ctx)
+	_, err = tx.Exec(ctx, `INSERT INTO withdrawals (order_number, user_id, amount) VALUES ($1,$2,$3)`, num, userID, amount)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (r *withdrawalRepo) ListByUser(ctx context.Context, userID int64) ([]domain.Withdrawal, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return nil, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    rows, err := tx.Query(ctx, `SELECT order_number, user_id, amount, processed_at FROM withdrawals WHERE user_id=$1 ORDER BY processed_at DESC`, userID)
-    if err != nil {
-        return nil, err
-    }
-    defer rows.Close()
+	rows, err := tx.Query(ctx, `SELECT order_number, user_id, amount, processed_at FROM withdrawals WHERE user_id=$1 ORDER BY processed_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-    var res []domain.Withdrawal
-    for rows.Next() {
-        var w domain.Withdrawal
-        if err = rows.Scan(&w.Number, &w.UserID, &w.Amount, &w.ProcessedAt); err != nil {
-            return nil, err
-        }
-        res = append(res, w)
-    }
-    if rows.Err() != nil {
-        return nil, rows.Err()
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return nil, err
-    }
-    return res, nil
+	var res []domain.Withdrawal
+	for rows.Next() {
+		var w domain.Withdrawal
+		if err = rows.Scan(&w.Number, &w.UserID, &w.Amount, &w.ProcessedAt); err != nil {
+			return nil, err
+		}
+		res = append(res, w)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 func (r *withdrawalRepo) SumByUser(ctx context.Context, userID int64) (decimal.Decimal, error) {
-    tx, ctx, cancel, err := beginTx(ctx, r.pool)
-    if err != nil {
-        return decimal.Zero, err
-    }
-    defer cancel()
-    defer tx.Rollback(ctx)
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
 
-    var sum decimal.Decimal
-    err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(amount),0) FROM withdrawals WHERE user_id=$1`, userID).Scan(&sum)
-    if err != nil {
-        return decimal.Zero, err
-    }
-    if err = tx.Commit(ctx); err != nil {
-        return decimal.Zero, err
-    }
-    return sum, nil
+	var sum decimal.Decimal
+	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(amount),0) FROM withdrawals WHERE user_id=$1`, userID).Scan(&sum)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return decimal.Zero, err
+	}
+	return sum, nil
+}
+
+func (r *withdrawalRepo) Withdraw(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
+
+	var accrual decimal.Decimal
+	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(accrual),0) FROM orders WHERE user_id=$1`, userID).Scan(&accrual)
+	if err != nil {
+		return err
+	}
+	var withdrawn decimal.Decimal
+	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(amount),0) FROM withdrawals WHERE user_id=$1`, userID).Scan(&withdrawn)
+	if err != nil {
+		return err
+	}
+	if accrual.Sub(withdrawn).Cmp(amount) < 0 {
+		return domain.ErrInsufficientBalance
+	}
+	_, err = tx.Exec(ctx, `INSERT INTO withdrawals (order_number, user_id, amount) VALUES ($1,$2,$3)`, num, userID, amount)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }


### PR DESCRIPTION
## Summary
- add `ErrInsufficientBalance` error
- extend `WithdrawalRepo` with `Withdraw` method
- implement withdrawal logic in postgres repository
- create `BalanceService` for withdrawing points
- deliver `/api/user/balance/withdraw` handler
- test withdrawal handler for success, insufficient funds and bad order number

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbedc1ab4832e91aad9243a6bba09