### PR TITLE
Implement withdrawals list handler

### DIFF
--- a/internal/delivery/http/withdrawals.go
+++ b/internal/delivery/http/withdrawals.go
@@ -1,0 +1,50 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+// WithdrawalRepo defines methods required to fetch withdrawals.
+type WithdrawalRepo interface {
+	ListByUser(ctx context.Context, userID int64) ([]domain.Withdrawal, error)
+}
+
+// Withdrawals returns handler for GET /api/user/withdrawals.
+func Withdrawals(repo WithdrawalRepo) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := UserIDFromCtx(r.Context())
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		list, err := repo.ListByUser(r.Context(), userID)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if len(list) == 0 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		type respItem struct {
+			Order       string  `json:"order"`
+			Sum         float64 `json:"sum"`
+			ProcessedAt string  `json:"processed_at"`
+		}
+		resp := make([]respItem, len(list))
+		for i, it := range list {
+			resp[i] = respItem{
+				Order:       it.Number,
+				Sum:         it.Amount.InexactFloat64(),
+				ProcessedAt: it.ProcessedAt.Format(time.RFC3339),
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/internal/delivery/http/withdrawals_test.go
+++ b/internal/delivery/http/withdrawals_test.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+type stubWithdrawalRepo struct {
+	listFunc func(ctx context.Context, userID int64) ([]domain.Withdrawal, error)
+}
+
+func (s *stubWithdrawalRepo) ListByUser(ctx context.Context, userID int64) ([]domain.Withdrawal, error) {
+	return s.listFunc(ctx, userID)
+}
+
+func TestWithdrawals_Unauthorized(t *testing.T) {
+	repo := &stubWithdrawalRepo{}
+	h := Withdrawals(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/withdrawals", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestWithdrawals_NoContent(t *testing.T) {
+	repo := &stubWithdrawalRepo{listFunc: func(ctx context.Context, userID int64) ([]domain.Withdrawal, error) {
+		if userID != 7 {
+			t.Fatalf("unexpected user id %d", userID)
+		}
+		return nil, nil
+	}}
+	h := Withdrawals(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/withdrawals", nil)
+	ctx := context.WithValue(req.Context(), userIDKey, int64(7))
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestWithdrawals_Success(t *testing.T) {
+	ts1 := time.Date(2020, 12, 9, 16, 9, 57, 0, time.FixedZone("", 3*3600))
+	ts2 := ts1.Add(-time.Hour)
+	repo := &stubWithdrawalRepo{listFunc: func(ctx context.Context, userID int64) ([]domain.Withdrawal, error) {
+		if userID != 1 {
+			t.Fatalf("unexpected user id %d", userID)
+		}
+		return []domain.Withdrawal{
+			{Number: "1", Amount: decimal.NewFromInt(5), ProcessedAt: ts1},
+			{Number: "2", Amount: decimal.NewFromFloat(7.5), ProcessedAt: ts2},
+		}, nil
+	}}
+	h := Withdrawals(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/withdrawals", nil)
+	ctx := context.WithValue(req.Context(), userIDKey, int64(1))
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+	var res []struct {
+		Order       string  `json:"order"`
+		Sum         float64 `json:"sum"`
+		ProcessedAt string  `json:"processed_at"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(res))
+	}
+	if res[0].Order != "1" || res[0].Sum != 5 || res[0].ProcessedAt != ts1.Format(time.RFC3339) {
+		t.Fatal("first item mismatch")
+	}
+	if res[1].Order != "2" || res[1].Sum != 7.5 || res[1].ProcessedAt != ts2.Format(time.RFC3339) {
+		t.Fatal("second item mismatch")
+	}
+}
+
+func TestWithdrawals_Error(t *testing.T) {
+	repo := &stubWithdrawalRepo{listFunc: func(ctx context.Context, userID int64) ([]domain.Withdrawal, error) {
+		return nil, errors.New("fail")
+	}}
+	h := Withdrawals(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/withdrawals", nil)
+	ctx := context.WithValue(req.Context(), userIDKey, int64(1))
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- add HTTP handler for `GET /api/user/withdrawals`
- implement tests covering success, no content, unauthorized and error cases

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbee93590832e927f1c8214388fe2