### PR TITLE
Add accrual client

### DIFF
--- a/internal/accrualclient/client.go
+++ b/internal/accrualclient/client.go
@@ -1,0 +1,89 @@
+package accrualclient
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Client requests order accrual information from the external service.
+type Client interface {
+	// Get retrieves accrual status for order number. If the service responds
+	// with 429 Too Many Requests the returned retryAfter specifies how long to
+	// wait before the next request.
+	Get(ctx context.Context, number string) (status string, accrual *decimal.Decimal, retryAfter time.Duration, err error)
+}
+
+// HTTPClient implements Client using net/http.
+type HTTPClient struct {
+	baseURL string
+	http    *http.Client
+}
+
+// New creates a new HTTPClient with provided base URL.
+func New(baseURL string) *HTTPClient {
+	return &HTTPClient{baseURL: strings.TrimRight(baseURL, "/"), http: &http.Client{}}
+}
+
+type getResponse struct {
+	Order   string           `json:"order"`
+	Status  string           `json:"status"`
+	Accrual *decimal.Decimal `json:"accrual"`
+}
+
+// Get implements Client using GET /api/orders/{number} request.
+func (c *HTTPClient) Get(ctx context.Context, number string) (string, *decimal.Decimal, time.Duration, error) {
+	url := fmt.Sprintf("%s/api/orders/%s", c.baseURL, number)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", nil, 0, err
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return "", nil, 0, nil
+	case http.StatusTooManyRequests:
+		raStr := resp.Header.Get("Retry-After")
+		if sec, err := strconv.Atoi(raStr); err == nil {
+			return "", nil, time.Duration(sec) * time.Second, nil
+		}
+		return "", nil, 0, nil
+	}
+
+	if resp.StatusCode > 299 {
+		return "", nil, 0, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var body io.Reader = resp.Body
+	if resp.Header.Get("Content-Encoding") == "gzip" {
+		gz, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return "", nil, 0, err
+		}
+		defer gz.Close()
+		body = gz
+	}
+
+	var gr getResponse
+	if err := json.NewDecoder(body).Decode(&gr); err != nil {
+		return "", nil, 0, err
+	}
+	return gr.Status, gr.Accrual, 0, nil
+}
+
+var _ Client = (*HTTPClient)(nil)

--- a/internal/accrualclient/client_test.go
+++ b/internal/accrualclient/client_test.go
@@ -1,0 +1,110 @@
+package accrualclient
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestHTTPClient_Get(t *testing.T) {
+	type want struct {
+		status  string
+		accrual *decimal.Decimal
+		retry   time.Duration
+		err     bool
+	}
+
+	dec := decimal.NewFromInt(10)
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    want
+	}{
+		{
+			name: "ok gzip",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Accept-Encoding") != "gzip" {
+					t.Errorf("missing Accept-Encoding header")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Encoding", "gzip")
+				w.WriteHeader(http.StatusOK)
+				gz := gzip.NewWriter(w)
+				json.NewEncoder(gz).Encode(map[string]any{
+					"order":   "42",
+					"status":  "PROCESSED",
+					"accrual": dec,
+				})
+				gz.Close()
+			},
+			want: want{status: "PROCESSED", accrual: &dec},
+		},
+		{
+			name: "no content",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Accept-Encoding") != "gzip" {
+					t.Errorf("missing Accept-Encoding header")
+				}
+				w.WriteHeader(http.StatusNoContent)
+			},
+			want: want{},
+		},
+		{
+			name: "retry",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Accept-Encoding") != "gzip" {
+					t.Errorf("missing Accept-Encoding header")
+				}
+				w.Header().Set("Retry-After", "2")
+				w.WriteHeader(http.StatusTooManyRequests)
+			},
+			want: want{retry: 2 * time.Second},
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			want: want{err: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			c := New(srv.URL)
+			status, accrual, retry, err := c.Get(context.Background(), "42")
+
+			if tt.want.err {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if status != tt.want.status {
+				t.Errorf("status %s != %s", status, tt.want.status)
+			}
+			if (accrual == nil) != (tt.want.accrual == nil) {
+				t.Fatalf("accrual nil mismatch")
+			}
+			if accrual != nil && !accrual.Equal(*tt.want.accrual) {
+				t.Errorf("accrual %s != %s", accrual, tt.want.accrual)
+			}
+			if retry != tt.want.retry {
+				t.Errorf("retry %v != %v", retry, tt.want.retry)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement HTTP client for the accrual system
- add unit tests with httptest server

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbeeb8bd0832ea8e7f635071c3086