### PR TITLE
Implement balance handler

### DIFF
--- a/internal/delivery/http/balance.go
+++ b/internal/delivery/http/balance.go
@@ -1,0 +1,41 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+// BalanceService defines method required to get user balance.
+type BalanceService interface {
+	GetBalance(ctx context.Context, userID int64) (domain.Balance, error)
+}
+
+// Balance returns handler for GET /api/user/balance.
+func Balance(svc BalanceService) http.HandlerFunc {
+	type respDTO struct {
+		Current   float64 `json:"current"`
+		Withdrawn float64 `json:"withdrawn"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		uid, ok := UserIDFromCtx(r.Context())
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		bal, err := svc.GetBalance(r.Context(), uid)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		resp := respDTO{
+			Current:   bal.Current.InexactFloat64(),
+			Withdrawn: bal.Withdrawn.InexactFloat64(),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/internal/delivery/http/balance_test.go
+++ b/internal/delivery/http/balance_test.go
@@ -1,0 +1,107 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+)
+
+type stubBalanceSvc struct {
+	getFunc func(ctx context.Context, userID int64) (domain.Balance, error)
+}
+
+func (s *stubBalanceSvc) GetBalance(ctx context.Context, userID int64) (domain.Balance, error) {
+	return s.getFunc(ctx, userID)
+}
+
+func TestBalance_Unauthorized(t *testing.T) {
+	svc := &stubBalanceSvc{}
+	h := Balance(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/balance", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestBalance_Success(t *testing.T) {
+	svc := &stubBalanceSvc{getFunc: func(ctx context.Context, userID int64) (domain.Balance, error) {
+		if userID != 1 {
+			t.Fatalf("unexpected user id %d", userID)
+		}
+		return domain.Balance{Current: decimal.NewFromFloat(10.5), Withdrawn: decimal.NewFromInt(3)}, nil
+	}}
+	h := Balance(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/balance", nil)
+	ctx := context.WithValue(req.Context(), userIDKey, int64(1))
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+	var resp struct {
+		Current   float64 `json:"current"`
+		Withdrawn float64 `json:"withdrawn"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Current != 10.5 || resp.Withdrawn != 3 {
+		t.Fatalf("unexpected resp %+v", resp)
+	}
+}
+
+func TestBalance_Zero(t *testing.T) {
+	svc := &stubBalanceSvc{getFunc: func(ctx context.Context, userID int64) (domain.Balance, error) {
+		return domain.Balance{Current: decimal.Zero, Withdrawn: decimal.Zero}, nil
+	}}
+	h := Balance(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/balance", nil)
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(5)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+	var resp struct {
+		Current   float64 `json:"current"`
+		Withdrawn float64 `json:"withdrawn"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Current != 0 || resp.Withdrawn != 0 {
+		t.Fatalf("unexpected resp %+v", resp)
+	}
+}
+
+func TestBalance_Error(t *testing.T) {
+	svc := &stubBalanceSvc{getFunc: func(ctx context.Context, userID int64) (domain.Balance, error) {
+		return domain.Balance{}, errors.New("fail")
+	}}
+	h := Balance(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/user/balance", nil)
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- add balance handler for `/api/user/balance`
- test balance handler

## Testing
- `go test ./...` *(fails: OrderService redeclared in this block)*

------
https://chatgpt.com/codex/tasks/task_e_687cc30558b8832e93f23b3b7e21ff9c