### PR TITLE
Implement withdrawal endpoint with tests

### DIFF
--- a/internal/delivery/http/withdraw.go
+++ b/internal/delivery/http/withdraw.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+	"github.com/Hobrus/gophermarket/pkg/luhn"
+	"github.com/shopspring/decimal"
+)
+
+// WithdrawalService defines method required for balance withdrawal.
+type WithdrawalService interface {
+	Withdraw(ctx context.Context, userID int64, number string, amount decimal.Decimal) error
+}
+
+// Withdraw returns handler for POST /api/user/balance/withdraw.
+func Withdraw(svc WithdrawalService) http.HandlerFunc {
+	type reqDTO struct {
+		Order string  `json:"order"`
+		Sum   float64 `json:"sum"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		uid, ok := UserIDFromCtx(r.Context())
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var req reqDTO
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if !luhn.IsValid(req.Order) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return
+		}
+		err := svc.Withdraw(r.Context(), uid, req.Order, decimal.NewFromFloat(req.Sum))
+		if err != nil {
+			switch {
+			case errors.Is(err, domain.ErrInsufficientFunds):
+				w.WriteHeader(http.StatusPaymentRequired)
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/internal/delivery/http/withdraw_test.go
+++ b/internal/delivery/http/withdraw_test.go
@@ -1,0 +1,72 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+	"github.com/shopspring/decimal"
+)
+
+type stubWithdrawSvc struct {
+	withdrawFunc func(ctx context.Context, userID int64, number string, amount decimal.Decimal) error
+}
+
+func (s *stubWithdrawSvc) Withdraw(ctx context.Context, userID int64, number string, amount decimal.Decimal) error {
+	return s.withdrawFunc(ctx, userID, number, amount)
+}
+
+func TestWithdraw_Success(t *testing.T) {
+	svc := &stubWithdrawSvc{withdrawFunc: func(ctx context.Context, userID int64, number string, amount decimal.Decimal) error {
+		if userID != 1 || number != "2377225624" || !amount.Equal(decimal.NewFromInt(10)) {
+			t.Fatalf("unexpected args")
+		}
+		return nil
+	}}
+	h := Withdraw(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/balance/withdraw", bytes.NewBufferString(`{"order":"2377225624","sum":10}`))
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestWithdraw_Insufficient(t *testing.T) {
+	svc := &stubWithdrawSvc{withdrawFunc: func(ctx context.Context, userID int64, number string, amount decimal.Decimal) error {
+		return domain.ErrInsufficientFunds
+	}}
+	h := Withdraw(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/balance/withdraw", bytes.NewBufferString(`{"order":"2377225624","sum":5}`))
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(2)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestWithdraw_InvalidOrder(t *testing.T) {
+	svc := &stubWithdrawSvc{withdrawFunc: func(ctx context.Context, userID int64, number string, amount decimal.Decimal) error {
+		t.Errorf("should not be called")
+		return nil
+	}}
+	h := Withdraw(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/user/balance/withdraw", bytes.NewBufferString(`{"order":"123","sum":1}`))
+	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", w.Result().StatusCode)
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -9,4 +9,6 @@ var (
 	ErrConflictOther = errors.New("conflict: already uploaded by other user")
 	// ErrNotFound is returned when requested entity is not found.
 	ErrNotFound = errors.New("not found")
+	// ErrInsufficientFunds indicates not enough balance for withdrawal.
+	ErrInsufficientFunds = errors.New("insufficient funds")
 )

--- a/internal/service/withdraw.go
+++ b/internal/service/withdraw.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Hobrus/gophermarket/internal/domain"
+	"github.com/Hobrus/gophermarket/internal/repository"
+	"github.com/shopspring/decimal"
+)
+
+// WithdrawService provides withdrawal operations.
+type WithdrawService struct {
+	orders      repository.OrderRepo
+	withdrawals repository.WithdrawalRepo
+}
+
+// NewWithdrawService creates a new WithdrawService instance.
+func NewWithdrawService(o repository.OrderRepo, w repository.WithdrawalRepo) *WithdrawService {
+	return &WithdrawService{orders: o, withdrawals: w}
+}
+
+// Withdraw deducts amount from user's balance if sufficient.
+// Returns ErrInsufficientFunds if current balance is less than amount.
+func (s *WithdrawService) Withdraw(ctx context.Context, userID int64, number string, amount decimal.Decimal) error {
+	totalAccrual, err := s.orders.SumProcessedAccrualByUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	totalWithdrawn, err := s.withdrawals.SumByUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	current := totalAccrual.Sub(totalWithdrawn)
+	if current.Cmp(amount) < 0 {
+		return domain.ErrInsufficientFunds
+	}
+	return s.withdrawals.Create(ctx, number, userID, amount)
+}


### PR DESCRIPTION
## Summary
- add domain error for insufficient funds
- implement withdrawal service logic
- add HTTP handler for POST `/api/user/balance/withdraw`
- cover withdrawal handler with tests

## Testing
- `go test ./...` *(fails: build errors and missing Docker)*

------
https://chatgpt.com/codex/tasks/task_e_687cc623343c832e8ffaef9358ea4cb1