### PR TITLE
Add gzip middleware support

### DIFF
--- a/internal/delivery/http/order_test.go
+++ b/internal/delivery/http/order_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Hobrus/gophermarket/internal/domain"
+	"github.com/Hobrus/gophermarket/pkg/middleware"
 )
 
 type stubOrderService struct {
@@ -118,7 +119,7 @@ func TestUploadOrder(t *testing.T) {
 
 	for _, tt := range tests {
 		svc := &stubOrderService{addFunc: tt.addFn}
-		router := NewOrdersRouter(svc)
+		router := middleware.Gzip(5)(NewOrderRouter(svc))
 
 		var buf bytes.Buffer
 		if tt.gzip && !tt.noCompress {

--- a/internal/delivery/http/orders.go
+++ b/internal/delivery/http/orders.go
@@ -12,19 +12,19 @@ import (
 	"github.com/Hobrus/gophermarket/internal/domain"
 )
 
-// OrderService defines method required for listing user orders.
-type OrderService interface {
+// ListService defines method required for listing user orders.
+type ListService interface {
 	ListByUser(ctx context.Context, userID int64) ([]domain.Order, error)
 }
 
 // NewOrdersRouter creates chi router with user orders endpoints.
-func NewOrdersRouter(svc OrderService) http.Handler {
+func NewOrdersRouter(svc ListService) http.Handler {
 	r := chi.NewRouter()
 	r.Get("/api/user/orders", listOrders(svc))
 	return r
 }
 
-func listOrders(svc OrderService) http.HandlerFunc {
+func listOrders(svc ListService) http.HandlerFunc {
 	type orderDTO struct {
 		Number     string   `json:"number"`
 		Status     string   `json:"status"`

--- a/pkg/middleware/gzip.go
+++ b/pkg/middleware/gzip.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type gzipReadCloser struct {
+	io.Reader
+	gz *gzip.Reader
+	rc io.Closer
+}
+
+func (g *gzipReadCloser) Close() error {
+	_ = g.gz.Close()
+	if g.rc != nil {
+		return g.rc.Close()
+	}
+	return nil
+}
+
+// Gzip returns middleware that transparently decompresses request bodies
+// with Content-Encoding: gzip and compresses responses if the client
+// sends Accept-Encoding containing "gzip".
+func Gzip(level int) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Content-Encoding") == "gzip" {
+				gz, err := gzip.NewReader(r.Body)
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				r.Body = &gzipReadCloser{Reader: gz, gz: gz, rc: r.Body}
+				r.Header.Del("Content-Encoding")
+			}
+
+			if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+				gz, err := gzip.NewWriterLevel(w, level)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				defer gz.Close()
+
+				w.Header().Set("Content-Encoding", "gzip")
+				w.Header().Del("Content-Length")
+
+				gw := &gzipResponseWriter{ResponseWriter: w, Writer: gz}
+				next.ServeHTTP(gw, r)
+			} else {
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
+}
+
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	io.Writer
+}
+
+func (w *gzipResponseWriter) Write(p []byte) (int, error) {
+	return w.Writer.Write(p)
+}

--- a/pkg/middleware/gzip_test.go
+++ b/pkg/middleware/gzip_test.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGzip_Decompress(t *testing.T) {
+	called := false
+	h := Gzip(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		if string(b) != "hello" {
+			t.Fatalf("unexpected body %q", b)
+		}
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	gz.Write([]byte("hello"))
+	gz.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &buf)
+	req.Header.Set("Content-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if !called {
+		t.Fatal("handler not called")
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+}
+
+func TestGzip_DecompressBad(t *testing.T) {
+	h := Gzip(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler called")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString("bad"))
+	req.Header.Set("Content-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGzip_Compress(t *testing.T) {
+	h := Gzip(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("world"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Header().Get("Content-Encoding") != "gzip" {
+		t.Fatalf("missing encoding header")
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(w.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	data, _ := io.ReadAll(zr)
+	if string(data) != "world" {
+		t.Fatalf("unexpected body %q", data)
+	}
+}
+
+func TestGzip_NoCompress(t *testing.T) {
+	h := Gzip(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("plain"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("unexpected encoding header %s", w.Header().Get("Content-Encoding"))
+	}
+	if w.Body.String() != "plain" {
+		t.Fatalf("unexpected body %q", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- create gzip middleware for request decompression and response compression
- hook middleware into server setup
- rename order routers to avoid conflicts
- add tests for middleware
- update order handler and tests

## Testing
- `go build ./...`
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd0536948832ea6c9d5e53435ce75