### PR TITLE
Add rate limiting to accrual client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/swaggo/swag v1.16.5
 	github.com/testcontainers/testcontainers-go v0.38.0
 	golang.org/x/crypto v0.40.0
+	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8
 )
 
 require (


### PR DESCRIPTION
## Summary
- add a token bucket limiter to HTTPClient
- wait on the limiter before each external request
- drain initial tokens so the limiter starts empty
- test that concurrent calls obey the limit

## Testing
- `go test ./internal/accrualclient -run .`
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d20feb360832ea541821ac92bdade