### PR TITLE
Add health endpoints and k8s manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This repository contains a minimal implementation of the "Gophermart" loyalty se
 make run
 ```
 
-The server listens on port `8080` and responds to `GET /ping` with `200 OK`.
+The server listens on port `8080` and exposes health check endpoints:
+`GET /health/live` always returns `200 OK`, and `GET /health/ready` returns
+`200 OK` when the database is reachable.
 
 ## Jaeger
 

--- a/cmd/gophermart/main.go
+++ b/cmd/gophermart/main.go
@@ -114,6 +114,8 @@ func main() {
 
 	router.Get("/swagger/*", httpSwagger.Handler(httpSwagger.URL("/swagger/doc.json")))
 
+	router.Mount("/health", dhttp.NewHealthRouter(pool))
+
 	router.Mount("/", dhttp.NewRouter(authSvc))
 	router.Group(func(r chi.Router) {
 		r.Use(dhttp.JWT([]byte(cfg.JWTSecret)))

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gophermart
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gophermart
+  template:
+    metadata:
+      labels:
+        app: gophermart
+    spec:
+      containers:
+      - name: gophermart
+        image: gophermart:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: RUN_ADDRESS
+          value: ":8080"
+        - name: DATABASE_URI
+          value: "postgres://postgres:postgres@db:5432/gophermart?sslmode=disable"
+        - name: ACCRUAL_SYSTEM_ADDRESS
+          value: "http://accrual:8080"
+        - name: JWT_SECRET
+          value: "secret"
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gophermart
+spec:
+  selector:
+    app: gophermart
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP

--- a/internal/delivery/http/health.go
+++ b/internal/delivery/http/health.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// DBPinger describes minimal database ping capability.
+type DBPinger interface {
+	Ping(ctx context.Context) error
+}
+
+// NewHealthRouter creates chi router with health check endpoints.
+func NewHealthRouter(db DBPinger) http.Handler {
+	r := chi.NewRouter()
+	r.Get("/live", live())
+	r.Get("/ready", ready(db))
+	return r
+}
+
+// live returns 200 OK.
+// @Summary Liveness check
+// @Success 200 {string} string "OK"
+// @Router /health/live [get]
+func live() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// ready checks database connectivity.
+// @Summary Readiness check
+// @Success 200 {string} string "OK"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /health/ready [get]
+func ready(db DBPinger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+		if err := db.Ping(ctx); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}


### PR DESCRIPTION
## Summary
- add liveness and readiness handlers
- mount health router in main application
- document health endpoints in README
- provide Kubernetes deployment and service manifests

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d4c105798832eac58f1453e8b314d