### PR TITLE
Fix go vet issues

### DIFF
--- a/internal/delivery/http/auth_test.go
+++ b/internal/delivery/http/auth_test.go
@@ -36,12 +36,14 @@ func TestRegister_Success(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/user/register", bytes.NewBufferString(`{"login":"user","password":"pass"}`))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 	var c *http.Cookie
-	for _, ck := range w.Result().Cookies() {
+	for _, ck := range res.Cookies() {
 		if ck.Name == "AuthToken" {
 			c = ck
 			break
@@ -64,9 +66,11 @@ func TestRegister_Conflict(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/user/register", bytes.NewBufferString(`{"login":"a","password":"b"}`))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusConflict {
-		t.Fatalf("expected 409, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", res.StatusCode)
 	}
 }
 
@@ -79,9 +83,11 @@ func TestRegister_BadRequest(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/user/register", bytes.NewBufferString("{"))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.StatusCode)
 	}
 }
 
@@ -94,9 +100,11 @@ func TestLogin_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/user/login", bytes.NewBufferString(`{"login":"u","password":"p"}`))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
 	}
 }
 
@@ -112,12 +120,14 @@ func TestLogin_Success(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/user/login", bytes.NewBufferString(`{"login":"user","password":"pass"}`))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 	var c *http.Cookie
-	for _, ck := range w.Result().Cookies() {
+	for _, ck := range res.Cookies() {
 		if ck.Name == "AuthToken" {
 			c = ck
 			break

--- a/internal/delivery/http/balance_test.go
+++ b/internal/delivery/http/balance_test.go
@@ -28,9 +28,11 @@ func TestBalance_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/user/balance", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
 	}
 }
 
@@ -48,9 +50,11 @@ func TestBalance_Success(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 	var resp struct {
 		Current   float64 `json:"current"`
@@ -74,9 +78,11 @@ func TestBalance_Zero(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(5)))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 	var resp struct {
 		Current   float64 `json:"current"`
@@ -100,8 +106,10 @@ func TestBalance_Error(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", res.StatusCode)
 	}
 }

--- a/internal/delivery/http/middleware_jwt_test.go
+++ b/internal/delivery/http/middleware_jwt_test.go
@@ -19,12 +19,14 @@ func TestJWT_NoToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
 	if handlerCalled {
 		t.Fatal("handler should not be called")
 	}
-	if w.Result().StatusCode != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
 	}
 }
 
@@ -53,9 +55,11 @@ func TestJWT_WithToken(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "AuthToken", Value: tokenStr})
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 	if gotID != 42 {
 		t.Fatalf("expected id 42, got %d", gotID)

--- a/internal/delivery/http/order_test.go
+++ b/internal/delivery/http/order_test.go
@@ -138,9 +138,11 @@ func TestUploadOrder(t *testing.T) {
 		}
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
+		res := w.Result()
+		defer res.Body.Close()
 
-		if w.Result().StatusCode != tt.status {
-			t.Errorf("%s: expected %d, got %d", tt.name, tt.status, w.Result().StatusCode)
+		if res.StatusCode != tt.status {
+			t.Errorf("%s: expected %d, got %d", tt.name, tt.status, res.StatusCode)
 		}
 	}
 }

--- a/internal/delivery/http/orders_test.go
+++ b/internal/delivery/http/orders_test.go
@@ -34,9 +34,11 @@ func TestListOrders_NoOrders(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", res.StatusCode)
 	}
 }
 
@@ -60,9 +62,11 @@ func TestListOrders_Sorted(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 	var resp []struct {
 		Number     string   `json:"number"`
@@ -103,9 +107,11 @@ func TestListOrders_Paging(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(5)))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 	var resp []struct {
 		Number string `json:"number"`

--- a/internal/delivery/http/withdraw_test.go
+++ b/internal/delivery/http/withdraw_test.go
@@ -32,9 +32,11 @@ func TestWithdraw_Success(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
 	}
 }
 
@@ -48,9 +50,11 @@ func TestWithdraw_Insufficient(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(2)))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusPaymentRequired {
-		t.Fatalf("expected 402, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusPaymentRequired {
+		t.Fatalf("expected 402, got %d", res.StatusCode)
 	}
 }
 
@@ -65,8 +69,10 @@ func TestWithdraw_InvalidOrder(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), userIDKey, int64(1)))
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	res := w.Result()
+	defer res.Body.Close()
 
-	if w.Result().StatusCode != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d", w.Result().StatusCode)
+	if res.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", res.StatusCode)
 	}
 }

--- a/internal/delivery/http/withdrawals_test.go
+++ b/internal/delivery/http/withdrawals_test.go
@@ -29,9 +29,11 @@ func TestWithdrawals_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/user/withdrawals", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
 
-	if w.Result().StatusCode != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", w.Result().StatusCode)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
 	}
 }
 
@@ -52,9 +54,11 @@ func TestWithdrawals_NoContent(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
 
-	if w.Result().StatusCode != http.StatusNoContent {
-		t.Fatalf("expected 204, got %d", w.Result().StatusCode)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
 	}
 }
 
@@ -80,9 +84,11 @@ func TestWithdrawals_Success(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 	var res []struct {
 		Order       string  `json:"order"`
@@ -117,9 +123,11 @@ func TestWithdrawals_Error(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
 
-	if w.Result().StatusCode != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d", w.Result().StatusCode)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
 	}
 }
 
@@ -141,9 +149,11 @@ func TestWithdrawals_Paging(t *testing.T) {
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
 
-	if w.Result().StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 	var res []struct {
 		Order string `json:"order"`

--- a/internal/service/order_updater.go
+++ b/internal/service/order_updater.go
@@ -38,11 +38,12 @@ func (u *OrderUpdater) Run(ctx context.Context, parallel, batch int, interval ti
 			if err != nil {
 				continue
 			}
+		ordersLoop:
 			for _, o := range orders {
 				uid := o.UserID
 				select {
 				case <-ctx.Done():
-					break
+					break ordersLoop
 				case sem <- struct{}{}:
 				}
 				wg.Add(1)


### PR DESCRIPTION
## Summary
- close response bodies in http tests
- fix ineffective break in `OrderUpdater`

## Testing
- `go vet -vettool=$(which statictest) ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d7be90164832eb2a9eb33fb3daa0a