### PR TITLE
Fix JWT secret default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,7 +49,7 @@ func Load() (Config, error) {
 		return Config{}, errors.New("accrual address is required")
 	}
 	if cfg.JWTSecret == "" {
-		return Config{}, errors.New("JWT secret is required")
+		cfg.JWTSecret = "secret"
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,3 +45,19 @@ func TestLoad_MissingRequired(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 }
+
+func TestLoad_DefaultJWTSecret(t *testing.T) {
+	t.Setenv("DATABASE_URI", "db")
+	t.Setenv("ACCRUAL_SYSTEM_ADDRESS", "acc")
+	t.Setenv("JWT_SECRET", "")
+	os.Args = []string{"cmd"}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.JWTSecret != "secret" {
+		t.Errorf("expected default secret, got %s", cfg.JWTSecret)
+	}
+}


### PR DESCRIPTION
## Summary
- make JWT secret optional with a default value
- test that default secret is applied when env var not set

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d7fa3ee24832e9d56d6d4c41177c7