### PR TITLE
Fix chi router mounts causing panic

### DIFF
--- a/cmd/gophermart/main.go
+++ b/cmd/gophermart/main.go
@@ -116,11 +116,13 @@ func main() {
 
 	router.Mount("/health", dhttp.NewHealthRouter(pool))
 
-	router.Mount("/", dhttp.NewRouter(authSvc))
+	router.Post("/api/user/register", dhttp.Register(authSvc))
+	router.Post("/api/user/login", dhttp.Login(authSvc))
+
 	router.Group(func(r chi.Router) {
 		r.Use(dhttp.JWT([]byte(cfg.JWTSecret)))
-		r.Mount("/", dhttp.NewOrderRouter(orderSvc))
-		r.Mount("/", dhttp.NewOrdersRouter(orderRepo))
+		r.Post("/api/user/orders", dhttp.UploadOrder(orderSvc))
+		r.Get("/api/user/orders", dhttp.ListOrders(orderRepo))
 		r.Get("/api/user/balance", dhttp.Balance(balanceSvc))
 		r.Post("/api/user/balance/withdraw", dhttp.Withdraw(withdrawSvc))
 		r.Get("/api/user/withdrawals", dhttp.Withdrawals(withdrawalRepo))

--- a/internal/delivery/http/auth.go
+++ b/internal/delivery/http/auth.go
@@ -25,8 +25,8 @@ type credentials struct {
 // NewRouter creates chi router with authentication endpoints.
 func NewRouter(auth AuthService) http.Handler {
 	r := chi.NewRouter()
-	r.Post("/api/user/register", register(auth))
-	r.Post("/api/user/login", login(auth))
+	r.Post("/api/user/register", Register(auth))
+	r.Post("/api/user/login", Login(auth))
 	return r
 }
 
@@ -38,7 +38,7 @@ func NewRouter(auth AuthService) http.Handler {
 // @Success 409 {string} string "Conflict"
 // @Success 500 {string} string "Internal Server Error"
 // @Router /api/user/register [post]
-func register(auth AuthService) http.HandlerFunc {
+func Register(auth AuthService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var creds credentials
 		if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
@@ -76,7 +76,7 @@ func register(auth AuthService) http.HandlerFunc {
 // @Success 401 {string} string "Unauthorized"
 // @Success 500 {string} string "Internal Server Error"
 // @Router /api/user/login [post]
-func login(auth AuthService) http.HandlerFunc {
+func Login(auth AuthService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var creds credentials
 		if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {

--- a/internal/delivery/http/order.go
+++ b/internal/delivery/http/order.go
@@ -19,7 +19,7 @@ type UploadService interface {
 // NewOrderRouter creates router with order upload endpoint.
 func NewOrderRouter(svc UploadService) http.Handler {
 	r := chi.NewRouter()
-	r.Post("/api/user/orders", uploadOrder(svc))
+	r.Post("/api/user/orders", UploadOrder(svc))
 	return r
 }
 
@@ -34,7 +34,7 @@ func NewOrderRouter(svc UploadService) http.Handler {
 // @Success 422 {string} string "Unprocessable Entity"
 // @Success 500 {string} string "Internal Server Error"
 // @Router /api/user/orders [post]
-func uploadOrder(svc UploadService) http.HandlerFunc {
+func UploadOrder(svc UploadService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID, ok := UserIDFromCtx(r.Context())
 		if !ok {

--- a/internal/delivery/http/orders.go
+++ b/internal/delivery/http/orders.go
@@ -28,7 +28,7 @@ type ListService interface {
 // NewOrdersRouter creates chi router with user orders endpoints.
 func NewOrdersRouter(svc ListService) http.Handler {
 	r := chi.NewRouter()
-	r.Get("/api/user/orders", listOrders(svc))
+	r.Get("/api/user/orders", ListOrders(svc))
 	return r
 }
 
@@ -39,7 +39,7 @@ func NewOrdersRouter(svc ListService) http.Handler {
 // @Success 401 {string} string "Unauthorized"
 // @Success 500 {string} string "Internal Server Error"
 // @Router /api/user/orders [get]
-func listOrders(svc ListService) http.HandlerFunc {
+func ListOrders(svc ListService) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		uid, ok := UserIDFromCtx(r.Context())


### PR DESCRIPTION
## Summary
- add exported http handlers for auth and order endpoints
- register HTTP handlers directly in main without repeated mounts

## Testing
- `go build ./...`
- `go test ./...`
- `gophermarttest -test.v -test.run=^TestGophermart$ ...` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d81afbfcc832e8f1b0ef3997fbf32