### PR TITLE
Fix auth cookie and migrations

### DIFF
--- a/cmd/gophermart/main.go
+++ b/cmd/gophermart/main.go
@@ -97,6 +97,9 @@ func main() {
 	if err := otelpgx.RecordStats(pool, otelpgx.WithStatsMeterProvider(mp)); err != nil {
 		log.Fatal(err)
 	}
+	if err := postgres.ApplyMigrations(ctx, pool); err != nil {
+		log.Fatal(err)
+	}
 
 	userRepo, orderRepo, withdrawalRepo := postgres.New(pool)
 

--- a/internal/delivery/http/auth.go
+++ b/internal/delivery/http/auth.go
@@ -50,8 +50,6 @@ func Register(auth AuthService) http.HandlerFunc {
 			switch {
 			case errors.Is(err, domain.ErrConflictSelf):
 				w.WriteHeader(http.StatusConflict)
-			case err.Error() == "login too short":
-				w.WriteHeader(http.StatusBadRequest)
 			default:
 				w.WriteHeader(http.StatusInternalServerError)
 			}
@@ -62,7 +60,6 @@ func Register(auth AuthService) http.HandlerFunc {
 			Value:    token,
 			Path:     "/",
 			HttpOnly: true,
-			Secure:   true,
 		})
 		w.WriteHeader(http.StatusOK)
 	}
@@ -98,7 +95,6 @@ func Login(auth AuthService) http.HandlerFunc {
 			Value:    token,
 			Path:     "/",
 			HttpOnly: true,
-			Secure:   true,
 		})
 		w.WriteHeader(http.StatusOK)
 	}

--- a/internal/delivery/http/auth_test.go
+++ b/internal/delivery/http/auth_test.go
@@ -52,7 +52,7 @@ func TestRegister_Success(t *testing.T) {
 	if c == nil {
 		t.Fatal("cookie missing")
 	}
-	if c.Value != "token" || !c.HttpOnly || !c.Secure || c.Path != "/" {
+	if c.Value != "token" || !c.HttpOnly || c.Secure || c.Path != "/" {
 		t.Fatal("cookie properties incorrect")
 	}
 }
@@ -136,7 +136,7 @@ func TestLogin_Success(t *testing.T) {
 	if c == nil {
 		t.Fatal("cookie missing")
 	}
-	if c.Value != "tok" || !c.HttpOnly || !c.Secure || c.Path != "/" {
+	if c.Value != "tok" || !c.HttpOnly || c.Secure || c.Path != "/" {
 		t.Fatal("cookie properties incorrect")
 	}
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -24,9 +24,6 @@ func NewAuthService(repo repository.UserRepo, secret []byte) *AuthService {
 
 // Register registers a new user and returns JWT token.
 func (s *AuthService) Register(ctx context.Context, login, password string) (string, error) {
-	if len(login) < 3 {
-		return "", errors.New("login too short")
-	}
 	hash, err := crypto.HashPassword(password)
 	if err != nil {
 		return "", err

--- a/internal/storage/postgres/migrations.go
+++ b/internal/storage/postgres/migrations.go
@@ -1,20 +1,23 @@
 package postgres
 
 import (
-    "context"
-    "os"
-    "path/filepath"
+	"context"
+	"os"
+	"path/filepath"
 
-    "github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // applyMigrations executes initial SQL schema.
-func applyMigrations(ctx context.Context, pool *pgxpool.Pool) error {
-    path := filepath.Join("migrations", "0001_init.up.sql")
-    b, err := os.ReadFile(path)
-    if err != nil {
-        return err
-    }
-    _, err = pool.Exec(ctx, string(b))
-    return err
+// ApplyMigrations executes the initial SQL schema.
+// It is safe to call multiple times because the queries
+// in the migration script use "IF NOT EXISTS" clauses.
+func ApplyMigrations(ctx context.Context, pool *pgxpool.Pool) error {
+	path := filepath.Join("migrations", "0001_init.up.sql")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	_, err = pool.Exec(ctx, string(b))
+	return err
 }

--- a/internal/storage/postgres/repo_test.go
+++ b/internal/storage/postgres/repo_test.go
@@ -64,7 +64,7 @@ func setupPostgres(t *testing.T) (*pgxpool.Pool, func()) {
 		t.Fatal(err)
 	}
 
-	if err := applyMigrations(ctx, pool); err != nil {
+	if err := ApplyMigrations(ctx, pool); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary
- expose and use `ApplyMigrations` to initialize Postgres schema
- remove username length restriction
- drop `Secure` flag from auth cookies
- update tests to match new cookie options

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d866d0d34832ebf24a48e98ca5a44