### PR TITLE
Update Dockerfile to Go 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.22 AS build
+FROM golang:1.23 AS build
 WORKDIR /app
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
## Summary
- bump Go version in Dockerfile to 1.23

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889150ad4d0832e88e0d0b1fdfcbf54