### PR TITLE
Add PostgreSQL connection retry

### DIFF
--- a/cmd/gophermart/main.go
+++ b/cmd/gophermart/main.go
@@ -90,7 +90,7 @@ func main() {
 		otelpgx.WithTracerProvider(tp),
 		otelpgx.WithMeterProvider(mp),
 	)
-	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	pool, err := postgres.ConnectWithRetry(ctx, poolCfg, 5, time.Second)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/storage/postgres/client.go
+++ b/internal/storage/postgres/client.go
@@ -1,0 +1,36 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ConnectWithRetry tries to create a pgx pool with the specified number of
+// attempts. Between attempts it waits for the provided delay. The function
+// returns the pool once Ping succeeds.
+func ConnectWithRetry(ctx context.Context, cfg *pgxpool.Config, attempts int, delay time.Duration) (*pgxpool.Pool, error) {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		pool, err := pgxpool.NewWithConfig(ctx, cfg)
+		if err == nil {
+			ctxPing, cancel := context.WithTimeout(ctx, 5*time.Second)
+			err = pool.Ping(ctxPing)
+			cancel()
+			if err == nil {
+				return pool, nil
+			}
+			pool.Close()
+		}
+		lastErr = err
+		if i < attempts-1 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+	return nil, lastErr
+}


### PR DESCRIPTION
## Summary
- add `ConnectWithRetry` helper for Postgres
- use retry helper in `gophermart` startup

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688914f34b54832e81808d0b725431ba