### PR TITLE
Move PGX pool initialization into storage package

### DIFF
--- a/cmd/gophermart/main.go
+++ b/cmd/gophermart/main.go
@@ -13,9 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/exaring/otelpgx"
 	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riandyrn/otelchi"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -82,22 +80,8 @@ func main() {
 		_ = mp.Shutdown(ctx)
 	}()
 
-	poolCfg, err := pgxpool.ParseConfig(cfg.DatabaseURI)
+	pool, err := postgres.NewPool(ctx, cfg.DatabaseURI)
 	if err != nil {
-		log.Fatal(err)
-	}
-	poolCfg.ConnConfig.Tracer = otelpgx.NewTracer(
-		otelpgx.WithTracerProvider(tp),
-		otelpgx.WithMeterProvider(mp),
-	)
-	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if err := otelpgx.RecordStats(pool, otelpgx.WithStatsMeterProvider(mp)); err != nil {
-		log.Fatal(err)
-	}
-	if err := postgres.ApplyMigrations(ctx, pool); err != nil {
 		log.Fatal(err)
 	}
 

--- a/internal/storage/postgres/pool.go
+++ b/internal/storage/postgres/pool.go
@@ -1,0 +1,36 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/exaring/otelpgx"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel"
+)
+
+// NewPool creates and initializes a pgx pool using the provided DSN.
+// The pool is instrumented with OpenTelemetry and migrations are applied.
+func NewPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ConnConfig.Tracer = otelpgx.NewTracer(
+		otelpgx.WithTracerProvider(otel.GetTracerProvider()),
+		otelpgx.WithMeterProvider(otel.GetMeterProvider()),
+	)
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := otelpgx.RecordStats(pool, otelpgx.WithStatsMeterProvider(otel.GetMeterProvider())); err != nil {
+		pool.Close()
+		return nil, err
+	}
+	if err := ApplyMigrations(ctx, pool); err != nil {
+		pool.Close()
+		return nil, err
+	}
+	return pool, nil
+}


### PR DESCRIPTION
## Summary
- encapsulate PGX pool setup inside `postgres` package via new `NewPool` helper
- simplify main initialization by using `postgres.NewPool`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889151dda78832e83ea46e11b69f40b