### PR TITLE
Refactor postgres init

### DIFF
--- a/cmd/gophermart/main.go
+++ b/cmd/gophermart/main.go
@@ -13,9 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/exaring/otelpgx"
 	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riandyrn/otelchi"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
@@ -82,22 +80,8 @@ func main() {
 		_ = mp.Shutdown(ctx)
 	}()
 
-	poolCfg, err := pgxpool.ParseConfig(cfg.DatabaseURI)
+	pool, err := postgres.NewPool(ctx, cfg.DatabaseURI, tp, mp)
 	if err != nil {
-		log.Fatal(err)
-	}
-	poolCfg.ConnConfig.Tracer = otelpgx.NewTracer(
-		otelpgx.WithTracerProvider(tp),
-		otelpgx.WithMeterProvider(mp),
-	)
-	pool, err := postgres.ConnectWithRetry(ctx, poolCfg, 5, time.Second)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if err := otelpgx.RecordStats(pool, otelpgx.WithStatsMeterProvider(mp)); err != nil {
-		log.Fatal(err)
-	}
-	if err := postgres.ApplyMigrations(ctx, pool); err != nil {
 		log.Fatal(err)
 	}
 

--- a/internal/storage/postgres/client.go
+++ b/internal/storage/postgres/client.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/exaring/otelpgx"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ConnectWithRetry tries to create a pgx pool with the specified number of
@@ -33,4 +36,34 @@ func ConnectWithRetry(ctx context.Context, cfg *pgxpool.Config, attempts int, de
 		}
 	}
 	return nil, lastErr
+}
+
+// NewPool parses connection string, configures OpenTelemetry instrumentation,
+// applies migrations and returns a ready-to-use pgx pool. It also retries
+// connection attempts a few times before failing.
+func NewPool(ctx context.Context, dsn string, tp trace.TracerProvider, mp metric.MeterProvider) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ConnConfig.Tracer = otelpgx.NewTracer(
+		otelpgx.WithTracerProvider(tp),
+		otelpgx.WithMeterProvider(mp),
+	)
+
+	pool, err := ConnectWithRetry(ctx, cfg, 5, time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = otelpgx.RecordStats(pool, otelpgx.WithStatsMeterProvider(mp)); err != nil {
+		pool.Close()
+		return nil, err
+	}
+
+	if err = ApplyMigrations(ctx, pool); err != nil {
+		pool.Close()
+		return nil, err
+	}
+	return pool, nil
 }


### PR DESCRIPTION
## Summary
- encapsulate pgx instrumentation and migrations in postgres.NewPool
- simplify main by using postgres.NewPool

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889176a2858832e9e44d12ba254b1c6