### PR TITLE
Handle 429 using error type

### DIFF
--- a/internal/accrualclient/client.go
+++ b/internal/accrualclient/client.go
@@ -21,9 +21,22 @@ import (
 // Client requests order accrual information from the external service.
 type Client interface {
 	// Get retrieves accrual status for order number. If the service responds
-	// with 429 Too Many Requests the returned retryAfter specifies how long to
-	// wait before the next request.
-	Get(ctx context.Context, number string) (status string, accrual *decimal.Decimal, retryAfter time.Duration, err error)
+	// with 429 Too Many Requests it returns a TooManyRequestsError containing
+	// the suggested retry delay.
+	Get(ctx context.Context, number string) (status string, accrual *decimal.Decimal, err error)
+}
+
+// TooManyRequestsError is returned when the external service responds with
+// HTTP 429. It contains the duration to wait before sending the next request.
+type TooManyRequestsError struct {
+	RetryAfter time.Duration
+}
+
+func (e TooManyRequestsError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("too many requests, retry after %v", e.RetryAfter)
+	}
+	return "too many requests"
 }
 
 // HTTPClient implements Client using net/http.
@@ -53,43 +66,44 @@ type getResponse struct {
 }
 
 // Get implements Client using GET /api/orders/{number} request.
-func (c *HTTPClient) Get(ctx context.Context, number string) (string, *decimal.Decimal, time.Duration, error) {
+func (c *HTTPClient) Get(ctx context.Context, number string) (string, *decimal.Decimal, error) {
 	if err := c.limiter.Wait(ctx); err != nil {
-		return "", nil, 0, err
+		return "", nil, err
 	}
 	url := fmt.Sprintf("%s/api/orders/%s", c.baseURL, number)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, err
 	}
 	req.Header.Set("Accept-Encoding", "gzip")
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, err
 	}
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusNoContent:
-		return "", nil, 0, nil
+		return "", nil, nil
 	case http.StatusTooManyRequests:
 		raStr := resp.Header.Get("Retry-After")
+		var dur time.Duration
 		if sec, err := strconv.Atoi(raStr); err == nil {
-			return "", nil, time.Duration(sec) * time.Second, nil
+			dur = time.Duration(sec) * time.Second
 		}
-		return "", nil, 0, nil
+		return "", nil, TooManyRequestsError{RetryAfter: dur}
 	}
 
 	if resp.StatusCode > 299 {
-		return "", nil, 0, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		return "", nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
 
 	var body io.Reader = resp.Body
 	if resp.Header.Get("Content-Encoding") == "gzip" {
 		gz, err := gzip.NewReader(resp.Body)
 		if err != nil {
-			return "", nil, 0, err
+			return "", nil, err
 		}
 		defer gz.Close()
 		body = gz
@@ -97,9 +111,9 @@ func (c *HTTPClient) Get(ctx context.Context, number string) (string, *decimal.D
 
 	var gr getResponse
 	if err := json.NewDecoder(body).Decode(&gr); err != nil {
-		return "", nil, 0, err
+		return "", nil, err
 	}
-	return gr.Status, gr.Accrual, 0, nil
+	return gr.Status, gr.Accrual, nil
 }
 
 var _ Client = (*HTTPClient)(nil)

--- a/internal/accrualclient/client_test.go
+++ b/internal/accrualclient/client_test.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -67,7 +68,7 @@ func TestHTTPClient_Get(t *testing.T) {
 				w.Header().Set("Retry-After", "2")
 				w.WriteHeader(http.StatusTooManyRequests)
 			},
-			want: want{retry: 2 * time.Second},
+			want: want{retry: 2 * time.Second, err: true},
 		},
 		{
 			name: "server error",
@@ -84,8 +85,18 @@ func TestHTTPClient_Get(t *testing.T) {
 			defer srv.Close()
 
 			c := New(srv.URL)
-			status, accrual, retry, err := c.Get(context.Background(), "42")
+			status, accrual, err := c.Get(context.Background(), "42")
 
+			if tt.want.retry > 0 {
+				var tme TooManyRequestsError
+				if !errors.As(err, &tme) {
+					t.Fatalf("expected TooManyRequestsError")
+				}
+				if tme.RetryAfter != tt.want.retry {
+					t.Errorf("retry %v != %v", tme.RetryAfter, tt.want.retry)
+				}
+				return
+			}
 			if tt.want.err {
 				if err == nil {
 					t.Fatalf("expected error %q", tt.want.errMsg)
@@ -106,9 +117,6 @@ func TestHTTPClient_Get(t *testing.T) {
 			}
 			if accrual != nil && !accrual.Equal(*tt.want.accrual) {
 				t.Errorf("accrual %s != %s", accrual, tt.want.accrual)
-			}
-			if retry != tt.want.retry {
-				t.Errorf("retry %v != %v", retry, tt.want.retry)
 			}
 		})
 	}

--- a/internal/service/order_updater.go
+++ b/internal/service/order_updater.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -78,19 +79,19 @@ func (u *OrderUpdater) Run(ctx context.Context, parallel, batch int, interval ti
 						return
 					}
 
-					status, accrual, retry, err := u.client.Get(ctx, num)
+					status, accrual, err := u.client.Get(ctx, num)
 					if err != nil {
-						return
-					}
-					if retry > 0 {
-						until := time.Now().Add(retry).UnixNano()
-						for {
-							old := atomic.LoadInt64(&u.sleepUntil)
-							if until <= old {
-								break
-							}
-							if atomic.CompareAndSwapInt64(&u.sleepUntil, old, until) {
-								break
+						var tme accrualclient.TooManyRequestsError
+						if errors.As(err, &tme) {
+							until := time.Now().Add(tme.RetryAfter).UnixNano()
+							for {
+								old := atomic.LoadInt64(&u.sleepUntil)
+								if until <= old {
+									break
+								}
+								if atomic.CompareAndSwapInt64(&u.sleepUntil, old, until) {
+									break
+								}
 							}
 						}
 						return


### PR DESCRIPTION
## Summary
- use a specific error type for accrual service rate limiting
- adjust order updater to read cooldown from that error
- update accrual client tests for new behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68892535ff5c832e9d20697ea67643a5