### PR TITLE
Use build tags for integration tests

### DIFF
--- a/internal/service/balance_test.go
+++ b/internal/service/balance_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package service
 
 import (
@@ -19,10 +22,6 @@ import (
 
 func setupPostgresBal(t *testing.T) (*pgxpool.Pool, func()) {
 	t.Helper()
-
-	if os.Getenv("ENABLE_DOCKER_TESTS") == "" {
-		t.Skip("skipping docker dependent tests; set ENABLE_DOCKER_TESTS=1 to run")
-	}
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{

--- a/internal/service/order_updater_test.go
+++ b/internal/service/order_updater_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package service
 
 import (
@@ -6,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path"
 	"path/filepath"
 	"sync"
@@ -24,10 +26,6 @@ import (
 
 func setupPostgres(t *testing.T) (*pgxpool.Pool, func()) {
 	t.Helper()
-
-	if os.Getenv("ENABLE_DOCKER_TESTS") == "" {
-		t.Skip("skipping docker dependent tests; set ENABLE_DOCKER_TESTS=1 to run")
-	}
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{

--- a/internal/storage/postgres/repo_test.go
+++ b/internal/storage/postgres/repo_test.go
@@ -1,10 +1,12 @@
+//go:build integration
+// +build integration
+
 package postgres
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -18,10 +20,6 @@ import (
 
 func setupPostgres(t *testing.T) (*pgxpool.Pool, func()) {
 	t.Helper()
-
-	if os.Getenv("ENABLE_DOCKER_TESTS") == "" {
-		t.Skip("skipping docker dependent tests; set ENABLE_DOCKER_TESTS=1 to run")
-	}
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{


### PR DESCRIPTION
## Summary
- gate docker-dependent tests behind the `integration` build tag

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889257c14dc832ea9bbf107257e301e