### PR TITLE
Fix race in withdrawals

### DIFF
--- a/cmd/gophermart/main.go
+++ b/cmd/gophermart/main.go
@@ -90,7 +90,7 @@ func main() {
 	authSvc := service.NewAuthService(userRepo, []byte(cfg.JWTSecret))
 	orderSvc := service.NewOrderService(orderRepo)
 	balanceSvc := service.NewBalanceService(orderRepo, withdrawalRepo)
-	withdrawSvc := service.NewWithdrawService(orderRepo, withdrawalRepo, balanceSvc)
+	withdrawSvc := service.NewWithdrawService(withdrawalRepo, balanceSvc)
 	updater := service.NewOrderUpdater(orderRepo, accrualclient.New(cfg.AccrualAddress), balanceSvc)
 
 	router := chi.NewRouter()

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -97,7 +97,7 @@ var _ = BeforeSuite(func() {
 	authSvc := service.NewAuthService(userRepo, []byte("secret"))
 	orderSvc := service.NewOrderService(orderRepo)
 	balanceSvc := service.NewBalanceService(orderRepo, withdrawalRepo)
-	withdrawSvc := service.NewWithdrawService(orderRepo, withdrawalRepo, balanceSvc)
+	withdrawSvc := service.NewWithdrawService(withdrawalRepo, balanceSvc)
 	updater := service.NewOrderUpdater(orderRepo, accrualclient.New(accrualAddr), balanceSvc)
 
 	router := chi.NewRouter()

--- a/internal/delivery/http/withdrawals_test.go
+++ b/internal/delivery/http/withdrawals_test.go
@@ -21,6 +21,9 @@ type stubWithdrawalRepo struct {
 func (s *stubWithdrawalRepo) ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Withdrawal, error) {
 	return s.listFunc(ctx, userID, limit, offset)
 }
+func (s *stubWithdrawalRepo) Withdraw(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
+	return nil
+}
 
 func TestWithdrawals_Unauthorized(t *testing.T) {
 	repo := &stubWithdrawalRepo{}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -38,6 +38,9 @@ type OrderRepo interface {
 type WithdrawalRepo interface {
 	// Create registers a withdrawal request for user.
 	Create(ctx context.Context, num string, userID int64, amount decimal.Decimal) error
+	// Withdraw atomically checks balance and registers withdrawal.
+	// Returns ErrInsufficientFunds if balance is not enough.
+	Withdraw(ctx context.Context, num string, userID int64, amount decimal.Decimal) error
 	// ListByUser returns withdrawal history for user sorted by processed time desc.
 	// Limit and offset define pagination parameters.
 	ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Withdrawal, error)

--- a/internal/service/balance_test.go
+++ b/internal/service/balance_test.go
@@ -154,6 +154,9 @@ type stubWithdrawalRepoBal struct{ calls int }
 func (s *stubWithdrawalRepoBal) Create(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
 	return nil
 }
+func (s *stubWithdrawalRepoBal) Withdraw(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
+	return nil
+}
 func (s *stubWithdrawalRepoBal) ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Withdrawal, error) {
 	return nil, nil
 }

--- a/internal/service/withdraw.go
+++ b/internal/service/withdraw.go
@@ -3,39 +3,25 @@ package service
 import (
 	"context"
 
-	"github.com/Hobrus/gophermarket/internal/domain"
 	"github.com/Hobrus/gophermarket/internal/repository"
 	"github.com/shopspring/decimal"
 )
 
 // WithdrawService provides withdrawal operations.
 type WithdrawService struct {
-	orders      repository.OrderRepo
 	withdrawals repository.WithdrawalRepo
 	inval       BalanceInvalidator
 }
 
 // NewWithdrawService creates a new WithdrawService instance.
-func NewWithdrawService(o repository.OrderRepo, w repository.WithdrawalRepo, b BalanceInvalidator) *WithdrawService {
-	return &WithdrawService{orders: o, withdrawals: w, inval: b}
+func NewWithdrawService(w repository.WithdrawalRepo, b BalanceInvalidator) *WithdrawService {
+	return &WithdrawService{withdrawals: w, inval: b}
 }
 
 // Withdraw deducts amount from user's balance if sufficient.
 // Returns ErrInsufficientFunds if current balance is less than amount.
 func (s *WithdrawService) Withdraw(ctx context.Context, userID int64, number string, amount decimal.Decimal) error {
-	totalAccrual, err := s.orders.SumProcessedAccrualByUser(ctx, userID)
-	if err != nil {
-		return err
-	}
-	totalWithdrawn, err := s.withdrawals.SumByUser(ctx, userID)
-	if err != nil {
-		return err
-	}
-	current := totalAccrual.Sub(totalWithdrawn)
-	if current.Cmp(amount) < 0 {
-		return domain.ErrInsufficientFunds
-	}
-	if err := s.withdrawals.Create(ctx, number, userID, amount); err != nil {
+	if err := s.withdrawals.Withdraw(ctx, number, userID, amount); err != nil {
 		return err
 	}
 	if s.inval != nil {

--- a/internal/storage/postgres/repo.go
+++ b/internal/storage/postgres/repo.go
@@ -233,6 +233,35 @@ func (r *withdrawalRepo) Create(ctx context.Context, num string, userID int64, a
 	return tx.Commit(ctx)
 }
 
+func (r *withdrawalRepo) Withdraw(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
+	tx, ctx, cancel, err := beginTx(ctx, r.pool)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer tx.Rollback(ctx)
+
+	var accrual decimal.Decimal
+	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(accrual),0) FROM orders WHERE status='PROCESSED' AND user_id=$1`, userID).Scan(&accrual)
+	if err != nil {
+		return err
+	}
+	var withdrawn decimal.Decimal
+	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(amount),0) FROM withdrawals WHERE user_id=$1`, userID).Scan(&withdrawn)
+	if err != nil {
+		return err
+	}
+	if accrual.Sub(withdrawn).Cmp(amount) < 0 {
+		return domain.ErrInsufficientFunds
+	}
+
+	_, err = tx.Exec(ctx, `INSERT INTO withdrawals (order_number, user_id, amount) VALUES ($1,$2,$3)`, num, userID, amount)
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 func (r *withdrawalRepo) ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Withdrawal, error) {
 	tx, ctx, cancel, err := beginTx(ctx, r.pool)
 	if err != nil {


### PR DESCRIPTION
## Summary
- make withdraw service use an atomic repository call
- add Withdraw method to WithdrawalRepo
- implement Withdraw in postgres repo
- update stubs and constructors

## Testing
- `go test ./...`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889259df31c832ea6fa0e7172de701f