### PR TITLE
Refactor PostgreSQL repo to avoid unnecessary transactions

### DIFF
--- a/internal/storage/postgres/repo.go
+++ b/internal/storage/postgres/repo.go
@@ -27,14 +27,8 @@ type orderRepo struct{ pool *pgxpool.Pool }
 
 type withdrawalRepo struct{ pool *pgxpool.Pool }
 
-func beginTx(ctx context.Context, pool *pgxpool.Pool) (pgx.Tx, context.Context, context.CancelFunc, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
-	if err != nil {
-		cancel()
-		return nil, nil, nil, err
-	}
-	return tx, ctx, cancel, nil
+func withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, timeout)
 }
 
 func isUniqueViolation(err error) bool {
@@ -48,45 +42,31 @@ func isUniqueViolation(err error) bool {
 // -- UserRepo implementation --
 
 func (r *userRepo) Create(ctx context.Context, login, hash string) (int64, error) {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return 0, err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
 	var id int64
-	err = tx.QueryRow(ctx, `INSERT INTO users (login, password_hash) VALUES ($1,$2) RETURNING id`, login, hash).Scan(&id)
+	err := r.pool.QueryRow(ctx, `INSERT INTO users (login, password_hash) VALUES ($1,$2) RETURNING id`, login, hash).Scan(&id)
 	if err != nil {
 		if isUniqueViolation(err) {
 			return 0, domain.ErrConflictSelf
 		}
 		return 0, err
 	}
-	if err = tx.Commit(ctx); err != nil {
-		return 0, err
-	}
 	return id, nil
 }
 
 func (r *userRepo) GetByLogin(ctx context.Context, login string) (domain.User, error) {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return domain.User{}, err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
 	var u domain.User
-	err = tx.QueryRow(ctx, `SELECT id, login, password_hash FROM users WHERE login=$1`, login).
+	err := r.pool.QueryRow(ctx, `SELECT id, login, password_hash FROM users WHERE login=$1`, login).
 		Scan(&u.ID, &u.Login, &u.PasswordHash)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.User{}, domain.ErrNotFound
 	}
 	if err != nil {
-		return domain.User{}, err
-	}
-	if err = tx.Commit(ctx); err != nil {
 		return domain.User{}, err
 	}
 	return u, nil
@@ -117,14 +97,10 @@ func (r *orderRepo) Add(ctx context.Context, num string, userID int64, status st
 }
 
 func (r *orderRepo) ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Order, error) {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return nil, err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
-	rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE user_id=$1 ORDER BY uploaded_at DESC LIMIT $2 OFFSET $3`, userID, limit, offset)
+	rows, err := r.pool.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE user_id=$1 ORDER BY uploaded_at DESC LIMIT $2 OFFSET $3`, userID, limit, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -141,23 +117,15 @@ func (r *orderRepo) ListByUser(ctx context.Context, userID int64, limit, offset 
 	}
 	if rows.Err() != nil {
 		return nil, rows.Err()
-	}
-
-	if err = tx.Commit(ctx); err != nil {
-		return nil, err
 	}
 	return orders, nil
 }
 
 func (r *orderRepo) GetUnprocessed(ctx context.Context, limit int) ([]domain.Order, error) {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return nil, err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
-	rows, err := tx.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE status IN ('NEW','PROCESSING') ORDER BY uploaded_at LIMIT $1`, limit)
+	rows, err := r.pool.Query(ctx, `SELECT number, user_id, status, accrual, uploaded_at FROM orders WHERE status IN ('NEW','PROCESSING') ORDER BY uploaded_at LIMIT $1`, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -175,42 +143,27 @@ func (r *orderRepo) GetUnprocessed(ctx context.Context, limit int) ([]domain.Ord
 	if rows.Err() != nil {
 		return nil, rows.Err()
 	}
-
-	if err = tx.Commit(ctx); err != nil {
-		return nil, err
-	}
 	return orders, nil
 }
 
 func (r *orderRepo) UpdateStatus(ctx context.Context, num, status string, accrual *decimal.Decimal) error {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
-	_, err = tx.Exec(ctx, `UPDATE orders SET status=$2, accrual=$3 WHERE number=$1`, num, status, accrual)
+	_, err := r.pool.Exec(ctx, `UPDATE orders SET status=$2, accrual=$3 WHERE number=$1`, num, status, accrual)
 	if err != nil {
 		return err
 	}
-	return tx.Commit(ctx)
+	return nil
 }
 
 func (r *orderRepo) SumProcessedAccrualByUser(ctx context.Context, userID int64) (decimal.Decimal, error) {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return decimal.Zero, err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
 	var sum decimal.Decimal
-	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(accrual),0) FROM orders WHERE status='PROCESSED' AND user_id=$1`, userID).Scan(&sum)
+	err := r.pool.QueryRow(ctx, `SELECT COALESCE(SUM(accrual),0) FROM orders WHERE status='PROCESSED' AND user_id=$1`, userID).Scan(&sum)
 	if err != nil {
-		return decimal.Zero, err
-	}
-	if err = tx.Commit(ctx); err != nil {
 		return decimal.Zero, err
 	}
 	return sum, nil
@@ -219,29 +172,21 @@ func (r *orderRepo) SumProcessedAccrualByUser(ctx context.Context, userID int64)
 // -- WithdrawalRepo implementation --
 
 func (r *withdrawalRepo) Create(ctx context.Context, num string, userID int64, amount decimal.Decimal) error {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
-	_, err = tx.Exec(ctx, `INSERT INTO withdrawals (order_number, user_id, amount) VALUES ($1,$2,$3)`, num, userID, amount)
+	_, err := r.pool.Exec(ctx, `INSERT INTO withdrawals (order_number, user_id, amount) VALUES ($1,$2,$3)`, num, userID, amount)
 	if err != nil {
 		return err
 	}
-	return tx.Commit(ctx)
+	return nil
 }
 
 func (r *withdrawalRepo) ListByUser(ctx context.Context, userID int64, limit, offset int) ([]domain.Withdrawal, error) {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return nil, err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
-	rows, err := tx.Query(ctx, `SELECT order_number, user_id, amount, processed_at FROM withdrawals WHERE user_id=$1 ORDER BY processed_at DESC LIMIT $2 OFFSET $3`, userID, limit, offset)
+	rows, err := r.pool.Query(ctx, `SELECT order_number, user_id, amount, processed_at FROM withdrawals WHERE user_id=$1 ORDER BY processed_at DESC LIMIT $2 OFFSET $3`, userID, limit, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -258,26 +203,16 @@ func (r *withdrawalRepo) ListByUser(ctx context.Context, userID int64, limit, of
 	if rows.Err() != nil {
 		return nil, rows.Err()
 	}
-	if err = tx.Commit(ctx); err != nil {
-		return nil, err
-	}
 	return res, nil
 }
 
 func (r *withdrawalRepo) SumByUser(ctx context.Context, userID int64) (decimal.Decimal, error) {
-	tx, ctx, cancel, err := beginTx(ctx, r.pool)
-	if err != nil {
-		return decimal.Zero, err
-	}
+	ctx, cancel := withTimeout(ctx)
 	defer cancel()
-	defer tx.Rollback(ctx)
 
 	var sum decimal.Decimal
-	err = tx.QueryRow(ctx, `SELECT COALESCE(SUM(amount),0) FROM withdrawals WHERE user_id=$1`, userID).Scan(&sum)
+	err := r.pool.QueryRow(ctx, `SELECT COALESCE(SUM(amount),0) FROM withdrawals WHERE user_id=$1`, userID).Scan(&sum)
 	if err != nil {
-		return decimal.Zero, err
-	}
-	if err = tx.Commit(ctx); err != nil {
 		return decimal.Zero, err
 	}
 	return sum, nil


### PR DESCRIPTION
## Summary
- remove unnecessary DB transactions in repository methods
- use per-query context timeouts instead

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688925c4492c832e9ebfd2f9e23044f1